### PR TITLE
Stop specifying resource names in AWS tests.

### DIFF
--- a/tests/terraform/aws/asg/main.tf
+++ b/tests/terraform/aws/asg/main.tf
@@ -1,10 +1,15 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
 }
 
 resource "aws_elb" "web-elb" {
-  name = "terraform-example-elb"
+  # name = "terraform-example-elb"
 
   # The same availability zone as our instances
   availability_zones = ["${split(",", var.availability_zones)}"]
@@ -27,7 +32,7 @@ resource "aws_elb" "web-elb" {
 
 resource "aws_autoscaling_group" "web-asg" {
   availability_zones   = ["${split(",", var.availability_zones)}"]
-  name                 = "terraform-example-asg"
+  # name                 = "terraform-example-asg"
   max_size             = "${var.asg_max}"
   min_size             = "${var.asg_min}"
   desired_capacity     = "${var.asg_desired}"
@@ -44,7 +49,7 @@ resource "aws_autoscaling_group" "web-asg" {
 }
 
 resource "aws_launch_configuration" "web-lc" {
-  name          = "terraform-example-lc"
+  # name          = "terraform-example-lc"
   image_id      = "${lookup(var.aws_amis, var.aws_region)}"
   instance_type = "${var.instance_type}"
 
@@ -56,7 +61,7 @@ resource "aws_launch_configuration" "web-lc" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "terraform_example_sg"
+  # name        = "terraform_example_sg"
   description = "Used in the terraform"
 
   # SSH access from anywhere

--- a/tests/terraform/aws/cognito-user-pool/main.tf
+++ b/tests/terraform/aws/cognito-user-pool/main.tf
@@ -1,5 +1,10 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 resource "aws_iam_role" "main" {
-  name = "terraform-example-lambda"
+  # name = "terraform-example-lambda"
 
   assume_role_policy = <<EOF
 {
@@ -20,14 +25,14 @@ EOF
 
 resource "aws_lambda_function" "main" {
   filename      = "lambda_function.zip"
-  function_name = "terraform-example"
+  # function_name = "terraform-example"
   role          = "${aws_iam_role.main.arn}"
   handler       = "exports.example"
   runtime       = "nodejs4.3"
 }
 
 resource "aws_iam_role" "cidp" {
-  name = "terraform-example-cognito-idp"
+  # name = "terraform-example-cognito-idp"
   path = "/service-role/"
 
   assume_role_policy = <<POLICY
@@ -53,7 +58,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "main" {
-  name = "terraform-example-cognito-idp"
+  # name = "terraform-example-cognito-idp"
   role = "${aws_iam_role.cidp.id}"
 
   policy = <<EOF
@@ -75,7 +80,7 @@ EOF
 }
 
 resource "aws_cognito_user_pool" "pool" {
-  name                       = "terraform-example"
+  # name                       = "terraform-example"
   email_verification_subject = "Device Verification Code"
   email_verification_message = "Please use the following code {####}"
   sms_verification_message   = "{####} Baz"

--- a/tests/terraform/aws/count/main.tf
+++ b/tests/terraform/aws/count/main.tf
@@ -1,10 +1,15 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
 }
 
 resource "aws_elb" "web" {
-  name = "terraform-example-elb"
+  # name = "terraform-example-elb"
 
   # The same availability zone as our instances
   availability_zones = ["${aws_instance.web.*.availability_zone}"]

--- a/tests/terraform/aws/ecs-alb/main.tf
+++ b/tests/terraform/aws/ecs-alb/main.tf
@@ -1,3 +1,8 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -42,7 +47,7 @@ resource "aws_route_table_association" "a" {
 ### Compute
 
 resource "aws_autoscaling_group" "app" {
-  name                 = "tf-test-asg"
+  # name                 = "tf-test-asg"
   vpc_zone_identifier  = ["${aws_subnet.main.*.id}"]
   min_size             = "${var.asg_min}"
   max_size             = "${var.asg_max}"

--- a/tests/terraform/aws/eip/main.tf
+++ b/tests/terraform/aws/eip/main.tf
@@ -1,3 +1,8 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -11,7 +16,7 @@ resource "aws_eip" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "eip_example"
+  # name        = "eip_example"
   description = "Used in the terraform"
 
   # SSH access from anywhere

--- a/tests/terraform/aws/elb/main.tf
+++ b/tests/terraform/aws/elb/main.tf
@@ -1,3 +1,8 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -51,7 +56,7 @@ resource "aws_route_table_association" "a" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "instance_sg"
+  # name        = "instance_sg"
   description = "Used in the terraform"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -83,7 +88,7 @@ resource "aws_security_group" "default" {
 # Our elb security group to access
 # the ELB over HTTP
 resource "aws_security_group" "elb" {
-  name        = "elb_sg"
+  # name        = "elb_sg"
   description = "Used in the terraform"
 
   vpc_id = "${aws_vpc.default.id}"
@@ -109,7 +114,7 @@ resource "aws_security_group" "elb" {
 }
 
 resource "aws_elb" "web" {
-  name = "example-elb"
+  # name = "example-elb"
 
   # The same availability zone as our instance
   subnets = ["${aws_subnet.tf_test_subnet.id}"]
@@ -141,7 +146,7 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "default" {
-  name                     = "lbpolicy"
+  # name                     = "lbpolicy"
   load_balancer            = "${aws_elb.web.id}"
   lb_port                  = 80
   cookie_expiration_period = 600

--- a/tests/terraform/aws/lambda/main.tf
+++ b/tests/terraform/aws/lambda/main.tf
@@ -1,3 +1,8 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -26,12 +31,12 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name               = "iam_for_lambda"
+  # name               = "iam_for_lambda"
   assume_role_policy = "${data.aws_iam_policy_document.policy.json}"
 }
 
 resource "aws_lambda_function" "lambda" {
-  function_name = "hello_lambda"
+  # function_name = "hello_lambda"
 
   filename         = "${data.archive_file.zip.output_path}"
   source_code_hash = "${data.archive_file.zip.output_sha}"

--- a/tests/terraform/aws/networking/region/security_group.tf
+++ b/tests/terraform/aws/networking/region/security_group.tf
@@ -1,5 +1,10 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 resource "aws_security_group" "region" {
-  name        = "region"
+  # name        = "region"
   description = "Open access within this region"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -12,7 +17,7 @@ resource "aws_security_group" "region" {
 }
 
 resource "aws_security_group" "internal-all" {
-  name        = "internal-all"
+  # name        = "internal-all"
   description = "Open access within the full internal network"
   vpc_id      = "${aws_vpc.main.id}"
 

--- a/tests/terraform/aws/networking/subnet/security_group.tf
+++ b/tests/terraform/aws/networking/subnet/security_group.tf
@@ -1,5 +1,10 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
 resource "aws_security_group" "az" {
-  name        = "az-${data.aws_availability_zone.target.name}"
+  # name        = "az-${data.aws_availability_zone.target.name}"
   description = "Open access within the AZ ${data.aws_availability_zone.target.name}"
   vpc_id      = "${var.vpc_id}"
 


### PR DESCRIPTION
Specifying explicit names for AWS resources harms the reliability of our
CI jobs, as it can cause conflicts between jobs that run concurrently or
jobs that fail to clean up their resources. By removing the explicit names,
we can take advantage of Pulumi's auto-naming and avoid these
situations.