### PR TITLE
Two small fixes

### DIFF
--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -25,10 +25,21 @@ import (
 
 // genListProperty generates code for as single list property.
 func (g *Generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
-	if len(n.Elements) == 0 {
+	switch len(n.Elements) {
+	case 0:
 		g.gen(w, "[]")
-	} else {
-		g.gen(w, "[")
+	case 1:
+		v := n.Elements[0]
+		if v.Type().IsList() {
+			// TF flattens list elements that are themselves lists into the parent list.
+			//
+			// TODO: if there is a list element that is dynamically a list, that also needs to be flattened. This is
+			// only knowable at runtime and will require a helper.
+			g.genf(w, "%v", v)
+		} else {
+			g.genf(w, "[%v]", v)
+		}
+	default:
 		g.indented(func() {
 			for _, v := range n.Elements {
 				// TF flattens list elements that are themselves lists into the parent list.

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -40,6 +40,7 @@ func (g *Generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 			g.genf(w, "[%v]", v)
 		}
 	default:
+		g.gen(w, "[")
 		g.indented(func() {
 			for _, v := range n.Elements {
 				// TF flattens list elements that are themselves lists into the parent list.

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -220,7 +220,7 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		}
 
 		if !b.hasCountIndex {
-			return nil, errors.Errorf("no count index in scope")
+			return &BoundLiteral{ExprType: TypeNumber, Value: 1.0}, nil
 		}
 
 		exprType = TypeNumber


### PR DESCRIPTION
- Allow references to count.index even if there is no count in scope,
  which is the case for uncounted resources. Resolve these references to
  a literal "1.0".
- Format single-item lists more densely.