### PR TITLE
Tolerate missing plugins

### DIFF
--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -122,6 +122,8 @@ func (g *Generator) gen(w io.Writer, vs ...interface{}) {
 			g.genListProperty(w, v)
 		case *il.BoundMapProperty:
 			g.genMapProperty(w, v)
+		case *il.BoundError:
+			g.genError(w, v)
 		default:
 			contract.Failf("unexpected type in gen: %T", v)
 		}
@@ -139,6 +141,16 @@ func (g *Generator) genf(w io.Writer, format string, args ...interface{}) {
 		}
 	}
 	fmt.Fprintf(w, format, args...)
+}
+
+// genError generates code for a node that represents a binding error.
+func (g *Generator) genError(w io.Writer, v *il.BoundError) {
+	g.gen(w, "(() => {\n")
+	g.indented(func() {
+		g.genf(w, "%sthrow \"tf2pulumi error: %v\";\n", g.indent, v.Error.Error())
+		g.genf(w, "%sreturn %v;\n", g.indent, v.Value)
+	})
+	g.gen(w, g.indent, "})()")
 }
 
 // computeProperty generates code for the given property into a string ala fmt.Sprintf. It returns both the generated

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -85,7 +85,7 @@ func (b *propertyBinder) bindCall(n *ast.Call) (BoundExpr, error) {
 		exprType = TypeString
 	case "map":
 		if len(args)%2 != 0 {
-			return nil, errors.Errorf("the numbner of arguments to \"map\" must be even")
+			err = errors.Errorf("the numbner of arguments to \"map\" must be even")
 		}
 		exprType = TypeMap
 	case "merge":
@@ -103,10 +103,14 @@ func (b *propertyBinder) bindCall(n *ast.Call) (BoundExpr, error) {
 	case "zipmap":
 		exprType = TypeMap
 	default:
-		return nil, errors.Errorf("NYI: call to %s", n.Func)
+		err = errors.Errorf("NYI: call to %s", n.Func)
 	}
 
-	return &BoundCall{HILNode: n, ExprType: exprType, Args: args}, nil
+	boundCall := &BoundCall{HILNode: n, ExprType: exprType, Args: args}
+	if err != nil {
+		return &BoundError{Value: boundCall, NodeType: exprType, Error: err}, nil
+	}
+	return boundCall, nil
 }
 
 // bindConditional binds an HIL conditional expression.

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -85,7 +85,7 @@ func (b *propertyBinder) bindCall(n *ast.Call) (BoundExpr, error) {
 		exprType = TypeString
 	case "map":
 		if len(args)%2 != 0 {
-			err = errors.Errorf("the numbner of arguments to \"map\" must be even")
+			err = errors.Errorf("the number of arguments to \"map\" must be even")
 		}
 		exprType = TypeMap
 	case "merge":

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -400,6 +400,36 @@ func (n *BoundMapProperty) dump(d *dumper) {
 
 func (n *BoundMapProperty) isNode() {}
 
+// BoundError represents a binding error. This is used to preserve bound values in the case
+// of type mismatches and other errors.
+type BoundError struct {
+	// The type of the node.
+	NodeType Type
+	// A bound node (if any) associated with this error
+	Value BoundNode
+	// The binding error
+	Error error
+}
+
+// Type returns the type of the variable access expression.
+func (n *BoundError) Type() Type {
+	return n.NodeType
+}
+
+func (n *BoundError) dump(d *dumper) {
+	d.dump("(error ", fmt.Sprintf("%v", n.Type()))
+	if n.Value != nil {
+		d.indented(func() {
+			d.dump("\n", n.Value)
+		})
+		d.dump("\n", d.indent)
+	}
+	d.dump("\"%q\")", n.Error.Error())
+}
+
+func (n *BoundError) isNode() {}
+func (n *BoundError) isExpr() {}
+
 // DumpBoundNode dumps the string representation of the given bound node to the given writer.
 func DumpBoundNode(w io.Writer, e BoundNode) {
 	e.dump(&dumper{w: w})

--- a/il/boundTree_visitor.go
+++ b/il/boundTree_visitor.go
@@ -65,6 +65,15 @@ func visitBoundConditional(n *BoundConditional, pre, post BoundNodeVisitor) (Bou
 	return post(n)
 }
 
+func visitBoundError(n *BoundError, pre, post BoundNodeVisitor) (BoundNode, error) {
+	valueNode, err := VisitBoundNode(n.Value, pre, post)
+	if err != nil {
+		return nil, err
+	}
+	n.Value = valueNode
+	return post(n)
+}
+
 func visitBoundIndex(n *BoundIndex, pre, post BoundNodeVisitor) (BoundNode, error) {
 	targetExpr, err := VisitBoundExpr(n.TargetExpr, pre, post)
 	if err != nil {
@@ -186,6 +195,8 @@ func VisitBoundNode(n BoundNode, pre, post BoundNodeVisitor) (BoundNode, error) 
 		return visitBoundCall(n, pre, post)
 	case *BoundConditional:
 		return visitBoundConditional(n, pre, post)
+	case *BoundError:
+		return visitBoundError(n, pre, post)
 	case *BoundIndex:
 		return visitBoundIndex(n, pre, post)
 	case *BoundListProperty:

--- a/tests/terraform/aws/cognito-user-pool/main.tf
+++ b/tests/terraform/aws/cognito-user-pool/main.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "main" {
   # function_name = "terraform-example"
   role          = "${aws_iam_role.main.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_iam_role" "cidp" {


### PR DESCRIPTION
These changes allow the binder to tolerate the absence of resource
provider plugins. The code generated for a resource that has no plugin
information may be incorrect: in particular, property types and names
will not be available, so any mappings that differ based on that
information will be off.

This behavior is disabled by default, and can be enabled by passing the
`--allow-missing-plugins` flag when invoking `tf2pulumi`.