### PR TITLE
Refactor to make library-friendly

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,0 +1,104 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/command"
+	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/svchost"
+	"github.com/hashicorp/terraform/svchost/auth"
+	"github.com/hashicorp/terraform/svchost/disco"
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/tf2pulumi/gen"
+	"github.com/pulumi/tf2pulumi/gen/nodejs"
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+// Convert converts a Terraform module at the provided location into a Pulumi module, written to stdout.
+func Convert(opts Options) error {
+	// Set default options where appropriate.
+	if opts.Path == "" {
+		opts.Path = "."
+	}
+	if opts.Writer == nil {
+		opts.Writer = os.Stdout
+	}
+
+	services := disco.NewWithCredentialsSource(noCredentials{})
+	moduleStorage := module.NewStorage(filepath.Join(command.DefaultDataDir, "modules"), services)
+
+	mod, err := module.NewTreeModule("", opts.Path)
+	if err != nil {
+		return errors.Wrapf(err, "creating tree module")
+	}
+
+	if err = mod.Load(moduleStorage); err != nil {
+		return errors.Wrapf(err, "loading module")
+	}
+
+	log.Printf("loaded module: %v", mod)
+
+	gs, err := buildGraphs(mod, true, opts)
+	if err != nil {
+		return errors.Wrapf(err, "importing Terraform project graphs")
+	}
+
+	if err = gen.Generate(gs, nodejs.New("auto", opts.Writer)); err != nil {
+		return errors.Wrapf(err, "generating code")
+	}
+
+	return nil
+}
+
+type Options struct {
+	// AllowMissingPlugins, if true, code-gen continues even if resource provider plugins are missing.
+	AllowMissingPlugins bool
+	// Path, when set, overrides the default path (".") to load the source Terraform module from.
+	Path string
+	// Writer can be set to override the default behavior of writing the resulting code to stdout.
+	Writer io.Writer
+}
+
+type noCredentials struct{}
+
+func (noCredentials) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
+	return nil, nil
+}
+
+func buildGraphs(tree *module.Tree, isRoot bool, opts Options) ([]*il.Graph, error) {
+	// TODO: move this into the il package and unify modules based on path
+
+	children := []*il.Graph{}
+	for _, c := range tree.Children() {
+		cc, err := buildGraphs(c, false, opts)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, cc...)
+	}
+
+	g, err := il.BuildGraph(tree, opts.AllowMissingPlugins)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(children, g), nil
+}

--- a/gen/nodejs/archive.go
+++ b/gen/nodejs/archive.go
@@ -26,7 +26,7 @@ import (
 
 // computeArchiveInputs computes the inputs for a call to the pulumi.AssetArchive constructor based on the values
 // present in the given resource's bound input properties.
-func (g *Generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
+func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
 	contract.Require(r.Provider.Config.Name == "archive", "r")
 
 	buf := &bytes.Buffer{}
@@ -99,7 +99,7 @@ func (g *Generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 }
 
 // generateArchive generates a call to the pulumi.AssetArchive constructor for the given archive resource.
-func (g *Generator) generateArchive(r *il.ResourceNode) error {
+func (g *generator) generateArchive(r *il.ResourceNode) error {
 	contract.Require(r.Provider.Config.Name == "archive", "r")
 
 	// TODO: explicit dependencies (or any dependencies at all, really)
@@ -113,7 +113,7 @@ func (g *Generator) generateArchive(r *il.ResourceNode) error {
 		}
 
 		// Generate an asset archive.
-		fmt.Printf("const %s = new pulumi.asset.AssetArchive(%s);\n", name, inputs)
+		g.printf("const %s = new pulumi.asset.AssetArchive(%s);\n", name, inputs)
 	} else {
 		// Otherwise we need to Generate multiple resources in a loop.
 		count, _, err := g.computeProperty(r.Count, false, "")
@@ -125,10 +125,10 @@ func (g *Generator) generateArchive(r *il.ResourceNode) error {
 			return err
 		}
 
-		fmt.Printf("const %s: pulumi.asset.AssetArchive[] = [];\n", name)
-		fmt.Printf("for (let i = 0; i < %s; i++) {\n", count)
-		fmt.Printf("    %s.push(new pulumi.asset.AssetArchive(%s));\n", name, inputs)
-		fmt.Printf("}\n")
+		g.printf("const %s: pulumi.asset.AssetArchive[] = [];\n", name)
+		g.printf("for (let i = 0; i < %s; i++) {\n", count)
+		g.printf("    %s.push(new pulumi.asset.AssetArchive(%s));\n", name, inputs)
+		g.printf("}\n")
 	}
 
 	return nil

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -33,7 +33,7 @@ import (
 // in order to avoid unexpected issues with operator precedence.
 
 // genArithmetic generates code for the given arithmetic expression.
-func (g *Generator) genArithmetic(w io.Writer, n *il.BoundArithmetic) {
+func (g *generator) genArithmetic(w io.Writer, n *il.BoundArithmetic) {
 	op := ""
 	switch n.HILNode.Op {
 	case ast.ArithmeticOpAdd:
@@ -76,7 +76,7 @@ func (g *Generator) genArithmetic(w io.Writer, n *il.BoundArithmetic) {
 }
 
 // genApplyOutput generates code for a single argument to a `.apply` invocation.
-func (g *Generator) genApplyOutput(w io.Writer, n *il.BoundVariableAccess) {
+func (g *generator) genApplyOutput(w io.Writer, n *il.BoundVariableAccess) {
 	if rv, ok := n.TFVar.(*config.ResourceVariable); ok && rv.Multi && rv.Index == -1 {
 		g.genf(w, "pulumi.all(%v)", n)
 	} else {
@@ -85,7 +85,7 @@ func (g *Generator) genApplyOutput(w io.Writer, n *il.BoundVariableAccess) {
 }
 
 // genApply generates code for a single `.apply` invocation as represented by a call to the `__apply` intrinsic.
-func (g *Generator) genApply(w io.Writer, n *il.BoundCall) {
+func (g *generator) genApply(w io.Writer, n *il.BoundCall) {
 	// Extract the list of outputs and the continuation expression from the `__apply` arguments.
 	g.applyArgs = n.Args[:len(n.Args)-1]
 	then := n.Args[len(n.Args)-1]
@@ -118,7 +118,7 @@ func (g *Generator) genApply(w io.Writer, n *il.BoundCall) {
 }
 
 // genApplyArg generates a single reference to a resolved output value inside the context of a call top `.apply`.
-func (g *Generator) genApplyArg(w io.Writer, index int) {
+func (g *generator) genApplyArg(w io.Writer, index int) {
 	contract.Assert(g.applyArgs != nil)
 
 	// Extract the variable reference.
@@ -164,7 +164,7 @@ func (g *Generator) genApplyArg(w io.Writer, index int) {
 }
 
 // genCoercion generates code for a single call to the __coerce intrinsic that converts an expression between types.
-func (g *Generator) genCoercion(w io.Writer, n il.BoundExpr, toType il.Type) {
+func (g *generator) genCoercion(w io.Writer, n il.BoundExpr, toType il.Type) {
 	switch n.Type() {
 	case il.TypeBool:
 		if toType == il.TypeString {
@@ -205,7 +205,7 @@ func (g *Generator) genCoercion(w io.Writer, n il.BoundExpr, toType il.Type) {
 }
 
 // genCall generates code for a call expression.
-func (g *Generator) genCall(w io.Writer, n *il.BoundCall) {
+func (g *generator) genCall(w io.Writer, n *il.BoundCall) {
 	switch n.HILNode.Func {
 	case "__apply":
 		g.genApply(w, n)
@@ -343,17 +343,17 @@ func (g *Generator) genCall(w io.Writer, n *il.BoundCall) {
 }
 
 // genConditional generates code for a single conditional expression.
-func (g *Generator) genConditional(w io.Writer, n *il.BoundConditional) {
+func (g *generator) genConditional(w io.Writer, n *il.BoundConditional) {
 	g.genf(w, "(%v ? %v : %v)", n.CondExpr, n.TrueExpr, n.FalseExpr)
 }
 
 // genIndex generates code for a single index expression.
-func (g *Generator) genIndex(w io.Writer, n *il.BoundIndex) {
+func (g *generator) genIndex(w io.Writer, n *il.BoundIndex) {
 	g.genf(w, "%v[%v]", n.TargetExpr, n.KeyExpr)
 }
 
 // genLiteral generates code for a single literal expression
-func (g *Generator) genLiteral(w io.Writer, n *il.BoundLiteral) {
+func (g *generator) genLiteral(w io.Writer, n *il.BoundLiteral) {
 	switch n.ExprType {
 	case il.TypeBool:
 		g.genf(w, "%v", n.Value)
@@ -372,7 +372,7 @@ func (g *Generator) genLiteral(w io.Writer, n *il.BoundLiteral) {
 }
 
 // genOutput generates code for a single output expression.
-func (g *Generator) genOutput(w io.Writer, n *il.BoundOutput) {
+func (g *generator) genOutput(w io.Writer, n *il.BoundOutput) {
 	g.gen(w, "`")
 	for _, s := range n.Exprs {
 		if lit, ok := s.(*il.BoundLiteral); ok && lit.ExprType == il.TypeString {
@@ -385,7 +385,7 @@ func (g *Generator) genOutput(w io.Writer, n *il.BoundOutput) {
 }
 
 // genVariableAccess generates code for a single variable access expression.
-func (g *Generator) genVariableAccess(w io.Writer, n *il.BoundVariableAccess) {
+func (g *generator) genVariableAccess(w io.Writer, n *il.BoundVariableAccess) {
 	switch v := n.TFVar.(type) {
 	case *config.CountVariable:
 		g.gen(w, g.countIndex)

--- a/gen/nodejs/http.go
+++ b/gen/nodejs/http.go
@@ -26,7 +26,7 @@ import (
 
 // computeHTTPInputs computes the arguments for a call to request-promise-native's single function from the bound input
 // properties of the given http resource.
-func (g *Generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
+func (g *generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
 	urlProperty, ok := r.Properties.Elements["url"]
 	if !ok {
 		return "", errors.Errorf("missing required property \"url\" in resource %s", r.Config.Name)
@@ -55,7 +55,7 @@ func (g *Generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count str
 }
 
 // generateHTTP generates the given http resource as a call to request-promise-native's single exported function.
-func (g *Generator) generateHTTP(r *il.ResourceNode) error {
+func (g *generator) generateHTTP(r *il.ResourceNode) error {
 	contract.Require(r.Provider.Config.Name == "http", "r")
 
 	name := resName(r.Config.Type, r.Config.Name)
@@ -66,7 +66,7 @@ func (g *Generator) generateHTTP(r *il.ResourceNode) error {
 			return err
 		}
 
-		fmt.Printf("const %s = pulumi.output(rpn(%s).promise());\n", name, inputs)
+		g.printf("const %s = pulumi.output(rpn(%s).promise());\n", name, inputs)
 	} else {
 		count, _, err := g.computeProperty(r.Count, false, "")
 		if err != nil {
@@ -77,10 +77,10 @@ func (g *Generator) generateHTTP(r *il.ResourceNode) error {
 			return err
 		}
 
-		fmt.Printf("const %s: pulumi.Output<string>[] = [];\n", name)
-		fmt.Printf("for (let i = 0; i < %s; i++) {\n", count)
-		fmt.Printf("    %s.push(pulumi.output(rpn(%s).promise()));\n", name, inputs)
-		fmt.Printf("}\n")
+		g.printf("const %s: pulumi.Output<string>[] = [];\n", name)
+		g.printf("for (let i = 0; i < %s; i++) {\n", count)
+		g.printf("    %s.push(pulumi.output(rpn(%s).promise()));\n", name, inputs)
+		g.printf("}\n")
 	}
 
 	return nil

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -24,7 +24,7 @@ import (
 )
 
 // genListProperty generates code for as single list property.
-func (g *Generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
+func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 	switch len(n.Elements) {
 	case 0:
 		g.gen(w, "[]")
@@ -58,7 +58,7 @@ func (g *Generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 }
 
 // genMapProperty generates code for a single map property.
-func (g *Generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
+func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 	if len(n.Elements) == 0 {
 		g.gen(w, "{}")
 	} else {

--- a/main.go
+++ b/main.go
@@ -17,50 +17,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
-	"path/filepath"
 
-	"github.com/hashicorp/terraform/command"
-	"github.com/hashicorp/terraform/config/module"
-	"github.com/hashicorp/terraform/svchost"
-	"github.com/hashicorp/terraform/svchost/auth"
-	"github.com/hashicorp/terraform/svchost/disco"
-
-	"github.com/pulumi/tf2pulumi/gen"
-	"github.com/pulumi/tf2pulumi/gen/nodejs"
-	"github.com/pulumi/tf2pulumi/il"
+	"github.com/pulumi/tf2pulumi/convert"
 	"github.com/pulumi/tf2pulumi/version"
 )
 
-type noCredentials struct{}
-
-func (noCredentials) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
-	return nil, nil
-}
-
-func buildGraphs(tree *module.Tree, isRoot, tolerateMissingPlugins bool) ([]*il.Graph, error) {
-	// TODO: move this into the il package and unify modules based on path
-
-	children := []*il.Graph{}
-	for _, c := range tree.Children() {
-		cc, err := buildGraphs(c, false, tolerateMissingPlugins)
-		if err != nil {
-			return nil, err
-		}
-		children = append(children, cc...)
-	}
-
-	g, err := il.BuildGraph(tree, tolerateMissingPlugins)
-	if err != nil {
-		return nil, err
-	}
-
-	return append(children, g), nil
-}
-
 func main() {
-	tolerateMissingPlugins := flag.Bool("allow-missing-plugins", false,
+	var opts convert.Options
+	flag.BoolVar(&opts.AllowMissingPlugins, "allow-missing-plugins", false,
 		"allows code generation to continue if resource provider plugins are missing")
 
 	flag.Parse()
@@ -71,30 +36,8 @@ func main() {
 		return
 	}
 
-	services := disco.NewWithCredentialsSource(noCredentials{})
-	moduleStorage := module.NewStorage(filepath.Join(command.DefaultDataDir, "modules"), services)
-
-	mod, err := module.NewTreeModule("", ".")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not load module: %v\n", err)
-		os.Exit(-1)
-	}
-
-	if err = mod.Load(moduleStorage); err != nil {
-		fmt.Fprintf(os.Stderr, "could not load module: %v\n", err)
-		os.Exit(-1)
-	}
-
-	log.Printf("loaded module: %v", mod)
-
-	gs, err := buildGraphs(mod, true, *tolerateMissingPlugins)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not import Terraform project: %v\n", err)
-		os.Exit(-1)
-	}
-
-	if err = gen.Generate(gs, &nodejs.Generator{ProjectName: "auto"}); err != nil {
-		fmt.Fprintf(os.Stderr, "generation failed: %v\n", err)
+	if err := convert.Convert(opts); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
This changes a few things to make this code usable from within
a library, in addition to its existing CLI form:

* Move setup logic into a new package, convert

* Add options to control the existing flags behavior (ignoring
  missing plugins), the source path to read Terraform modules
  from, and the destination writer for the converted code

* Replace all fmt.Print* writes with calls to the custom writer

I am doing this as part of an experiment to leverage this library
in our pulumi-terraform bridge's document generation.