### PR TITLE
Emit module imports in a stable order

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1365,6 +1365,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6fc8e23b928c67267b76bcfe99529ad34556536c6d4720657ddff28b83fdf26f"
+  inputs-digest = "a202a0194d707be712b83a0d60ec3100314b9a705abd3c52742ad1b25ba762a9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -171,10 +171,8 @@ func (g *generator) print(a ...interface{}) {
 
 // println prints one or more values to the generator's output stream, followed by a newline.
 func (g *generator) println(a ...interface{}) {
-	_, err := fmt.Fprint(g.w, a...)
-	contract.IgnoreError(err)
-	_, err = fmt.Fprint(g.w, "\n")
-	contract.IgnoreError(err)
+	g.print(a...)
+	g.print("\n")
 }
 
 // prinft prints a formatted message to the generator's output stream.

--- a/il/boundTree_visitor.go
+++ b/il/boundTree_visitor.go
@@ -15,6 +15,8 @@
 package il
 
 import (
+	"sort"
+
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
@@ -97,8 +99,15 @@ func visitBoundListProperty(n *BoundListProperty, pre, post BoundNodeVisitor) (B
 }
 
 func visitBoundMapProperty(n *BoundMapProperty, pre, post BoundNodeVisitor) (BoundNode, error) {
-	for k, e := range n.Elements {
-		ee, err := VisitBoundNode(e, pre, post)
+	// Sort the keys to ensure a deterministic visitation order.
+	var keys []string
+	for k := range n.Elements {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		ee, err := VisitBoundNode(n.Elements[k], pre, post)
 		if err != nil {
 			return nil, err
 		}

--- a/il/rewriters.go
+++ b/il/rewriters.go
@@ -15,6 +15,8 @@
 package il
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hil/ast"
 	"github.com/hashicorp/terraform/config"
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
@@ -183,8 +185,15 @@ func RewriteAssets(n BoundNode) (BoundNode, error) {
 			return n, nil
 		}
 
-		for k, v := range m.Elements {
-			e, ok := v.(BoundExpr)
+		// Sort keys to ensure we visit in a deterministic order.
+		var keys []string
+		for k := range m.Elements {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			e, ok := m.Elements[k].(BoundExpr)
 			if !ok {
 				continue
 			}

--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/tf2pulumi/tests/terraform"
 )
 
-func integrationTest(t *testing.T, program *integration.ProgramTestOptions) {
+func integrationTest(t *testing.T, program *integration.ProgramTestOptions, compile bool) {
 	region := os.Getenv("AWS_REGION")
 	if region == "" {
 		t.Skipf("Skipping test due to missing AWS_REGION environment variable")
@@ -34,43 +34,48 @@ func integrationTest(t *testing.T, program *integration.ProgramTestOptions) {
 	program.Config["aws:region"] = region
 	program.ExpectRefreshChanges = true
 
-	terraform.IntegrationTest(t, program)
+	terraform.IntegrationTest(t, program, compile)
 }
 
 func TestASG(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, true)
 }
 
 func TestCognitoUserPool(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, true)
 }
 
 func TestCount(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, true)
 }
 
 func TestECSALB(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: call to cidrsubnet")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, true)
 }
 
 func TestEIP(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, true)
 }
 
 func TestELB(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, true)
 }
 
 func TestELB2(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, true)
+}
+
+func TestLBListener(t *testing.T) {
+	// Note we don't compile this one, since it contains semantic errors.
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, false)
 }
 
 func TestLambda(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, true)
 }
 
 func TestNetworking(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: provider instances")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"})
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, true)
 }

--- a/tests/terraform/aws/lb-listener/.gitignore
+++ b/tests/terraform/aws/lb-listener/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/tests/terraform/aws/lb-listener/Pulumi.yaml
+++ b/tests/terraform/aws/lb-listener/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: lb-listener
+runtime: nodejs
+description: LB Listener Example

--- a/tests/terraform/aws/lb-listener/index.base.ts
+++ b/tests/terraform/aws/lb-listener/index.base.ts
@@ -1,0 +1,30 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const aws_cognito_user_pool_pool = new aws.cognito.UserPool("pool", {});
+const aws_cognito_user_pool_client_client = new aws.cognito.UserPoolClient("client", {});
+const aws_cognito_user_pool_domain_domain = new aws.cognito.UserPoolDomain("domain", {});
+const aws_lb_front_end = new aws.elasticloadbalancingv2.LoadBalancer("front_end", {});
+const aws_lb_target_group_front_end = new aws.elasticloadbalancingv2.TargetGroup("front_end", {});
+const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener("front_end", {
+    defaultAction: pulumi.all([aws_cognito_user_pool_pool.arn, aws_cognito_user_pool_client_client.id, aws_cognito_user_pool_domain_domain.domain, aws_lb_target_group_front_end.arn]).apply(([__arg0, __arg1, __arg2, __arg3]) => (() => {
+        throw "tf2pulumi error: aws_lb_listener.front_end.default_action: expected at most one item in list, got 2";
+        return [
+            {
+                authenticateCognito: [{
+                    userPoolArn: __arg0,
+                    userPoolClientId: __arg1,
+                    userPoolDomain: __arg2,
+                }],
+                type: "authenticate-cognito",
+            },
+            {
+                targetGroupArn: __arg3,
+                type: "forward",
+            },
+        ];
+    })()),
+    loadBalancerArn: aws_lb_front_end.arn,
+    port: Number.parseFloat("80"),
+    protocol: "HTTP",
+});

--- a/tests/terraform/aws/lb-listener/main.tf
+++ b/tests/terraform/aws/lb-listener/main.tf
@@ -1,0 +1,42 @@
+# Regression test for https://github.com/pulumi/tf2pulumi/issues/32
+# Taken from the AWS Terraform documentation
+
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_target_group" "front_end" {
+  # ...
+}
+
+resource "aws_cognito_user_pool" "pool" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.front_end.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type  = "authenticate-cognito"
+    authenticate_cognito {
+      user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
+      user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
+      user_pool_domain    = "${aws_cognito_user_pool_domain.domain.domain}"
+    }
+  }
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+  }
+}

--- a/tests/terraform/aws/lb-listener/package.json
+++ b/tests/terraform/aws/lb-listener/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "lb-listener",
+    "devDependencies": {
+        "@types/node": "latest",
+        "@types/sprintf-js": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "sprintf-js": "latest"
+    }
+}

--- a/tests/terraform/aws/lb-listener/tsconfig.json
+++ b/tests/terraform/aws/lb-listener/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Module imports previously got emitted in a non-deterministic order.
This change sorts them by name to ensure determinism. Part of the
fixes required for pulumi/tf2pulumi#32.