### PR TITLE
Clean up some rough edges for library use

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	var opts convert.Options
-	flag.BoolVar(&opts.AllowMissingPlugins, "allow-missing-plugins", false,
+	flag.BoolVar(&opts.AllowMissingProviders, "allow-missing-plugins", false,
 		"allows code generation to continue if resource provider plugins are missing")
 
 	flag.Parse()


### PR DESCRIPTION
- Allow users of the convert package to specify a source for plugin
  information
- Allow users of the convert package to specify a logger to use for
  diagnostic information
- Simplify the plugin information source interface