### PR TITLE
Tolerate missing resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1365,6 +1365,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a202a0194d707be712b83a0d60ec3100314b9a705abd3c52742ad1b25ba762a9"
+  inputs-digest = "2b74cd67d6ff06f1d3716aec2a2719c2eaa0873687e41fc5d9f1cfa099a42fd6"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Allow the input configuration to refer to resources that do not exist in
the provider's schema information. This can occur for a couple reasons:
- The version of the provider expected by the configuration does not
  match the version of the provider described by the schema
- The input configuration has a bug