### PR TITLE
Add a `release` target to the Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,12 @@ For contributors we use the standard fork based workflow. Fork this repository, 
 ## Getting Help
 
 We're sure there are rough edges and we appreciate you helping out. If you want to talk with other folks hacking on Pulumi (or members of the Pulumi team!) come hang out `#contribute` channel in the [Pulumi Community Slack](https://slack.pulumi.io/).
+
+## Building Release Artifacts
+
+To build the `.tar.gz` files that make up a tf2pulumi release, run `make release`. This will produce two releasable artifacts:
+
+- tf2pulumi-linux-x64-vX.X.X.tar.gz
+- tf2pulumi-darwin-x64-vX.X.X.tar.gz
+
+These archives can then be uploaded as part of a GitHub Release.

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ test_fast::
 test_all::
 	PATH=$(PULUMI_BIN):$(PATH) go test -v -cover -timeout 1h ./tests/...
 
+release::
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/pulumi/tf2pulumi/version.Version=${VERSION}" github.com/pulumi/tf2pulumi
+	tar -c ./tf2pulumi | gzip > tf2pulumi-${VERSION}-linux-x64.tar.gz
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X github.com/pulumi/tf2pulumi/version.Version=${VERSION}" github.com/pulumi/tf2pulumi
+	tar -c ./tf2pulumi | gzip > tf2pulumi-${VERSION}-darwin-x64.tar.gz
+
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all


### PR DESCRIPTION
This target builds .tar.gz files that are appropriate for uploading as
part of a GitHub Release.