### PR TITLE
Optionally allow missing variables

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -67,8 +67,11 @@ func Convert(opts Options) error {
 }
 
 type Options struct {
-	// AllowMissingProviders, if true, code-gen continues even if resource providers are missing.
+	// AllowMissingProviders, if true, allows code-gen to continue even if resource providers are missing.
 	AllowMissingProviders bool
+	// AllowMissingVariables, if true, allows code-gen to continue even if the input configuration references missing
+	// variables.
+	AllowMissingVariables bool
 	// Path, when set, overrides the default path (".") to load the source Terraform module from.
 	Path string
 	// Writer can be set to override the default behavior of writing the resulting code to stdout.
@@ -99,6 +102,7 @@ func buildGraphs(tree *module.Tree, isRoot bool, opts Options) ([]*il.Graph, err
 
 	buildOpts := il.BuildOptions{
 		AllowMissingProviders: opts.AllowMissingProviders,
+		AllowMissingVariables: opts.AllowMissingVariables,
 		ProviderInfoSource:    opts.ProviderInfoSource,
 		Logger:                opts.Logger,
 	}

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -342,6 +342,10 @@ func (n *BoundVariableAccess) dump(d *dumper) {
 func (n *BoundVariableAccess) isNode() {}
 func (n *BoundVariableAccess) isExpr() {}
 
+func (n *BoundVariableAccess) IsMissingVariable() bool {
+	return n.ILNode == nil
+}
+
 // BoundListProperty is the bound form of an HCL list property. (e.g. `[ foo, bar ]`).
 type BoundListProperty struct {
 	// Schemas are the Terraform and Pulumi schemas associated with the list.

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func main() {
 	var opts convert.Options
 	flag.BoolVar(&opts.AllowMissingProviders, "allow-missing-plugins", false,
 		"allows code generation to continue if resource provider plugins are missing")
+	flag.BoolVar(&opts.AllowMissingVariables, "allow-missing-variables", false,
+		"allows code generation to continue if the config references missing variables")
 
 	flag.Parse()
 


### PR DESCRIPTION
These changes optionally allow binding (and therefore source generation)
to succeed even if the input configuration conatins references to
missing variables (resources/data sources/variables/etc.).

Fixes #45.