### PR TITLE
Fix identifier generation

### DIFF
--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -94,22 +94,18 @@ func isLegalIdentifier(s string) bool {
 // cleanName replaces characters that are not allowed in JavaScript identifiers with underscores. No attempt is made to
 // ensure that the result is unique.
 func cleanName(name string) string {
-	reader, writer := strings.NewReader(name), strings.Builder{}
-
-	// consume the leading character
-	c, _, err := reader.ReadRune()
-	if !isLegalIdentifierStart(c) {
-		writer.WriteRune('_')
-	}
-	for err == nil {
+	var builder strings.Builder
+	for i, c := range name {
 		if !isLegalIdentifierPart(c) {
-			writer.WriteRune('_')
+			builder.WriteRune('_')
 		} else {
-			writer.WriteRune(c)
+			if i == 0 && !isLegalIdentifierStart(c) {
+				builder.WriteRune('_')
+			}
+			builder.WriteRune(c)
 		}
-		c, _, err = reader.ReadRune()
 	}
-	return writer.String()
+	return builder.String()
 }
 
 // localName returns the name for a local value with the given Terraform name.

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -59,18 +60,56 @@ type generator struct {
 	w io.Writer
 }
 
-// cleanName replaces characters that are not allowed in Typescript identifiers with underscores. No attempt is made to
+// isLegalIdentifierStart returns true if it is legal for c to be the first character of a JavaScript identifier as per
+// ECMA-262.
+func isLegalIdentifierStart(c rune) bool {
+	return c == '$' || c == '_' ||
+		unicode.In(c, unicode.Lu, unicode.Ll, unicode.Lt, unicode.Lm, unicode.Lo, unicode.Nl)
+}
+
+// isLegalIdentifierPart returns true if it is legal for c to be part of a JavaScript identifier (besides the first
+// character) as per ECMA-262.
+func isLegalIdentifierPart(c rune) bool {
+	return isLegalIdentifierStart(c) || unicode.In(c, unicode.Mn, unicode.Mc, unicode.Nd, unicode.Pc)
+}
+
+// isLegalIdentifier returns true if s is a legal JavaScript identifier as per ECMA-262.
+func isLegalIdentifier(s string) bool {
+	reader := strings.NewReader(s)
+	c, _, _ := reader.ReadRune()
+	if !isLegalIdentifierStart(c) {
+		return false
+	}
+	for {
+		c, _, err := reader.ReadRune()
+		if err != nil {
+			return err == io.EOF
+		}
+		if !isLegalIdentifierPart(c) {
+			return false
+		}
+	}
+}
+
+// cleanName replaces characters that are not allowed in JavaScript identifiers with underscores. No attempt is made to
 // ensure that the result is unique.
 func cleanName(name string) string {
-	if !strings.ContainsAny(name, " -.") {
-		return name
+	reader, writer := strings.NewReader(name), strings.Builder{}
+
+	// consume the leading character
+	c, _, err := reader.ReadRune()
+	if !isLegalIdentifierStart(c) {
+		writer.WriteRune('_')
 	}
-	return strings.Map(func(r rune) rune {
-		if r == ' ' || r == '-' || r == '.' {
-			return '_'
+	for err == nil {
+		if !isLegalIdentifierPart(c) {
+			writer.WriteRune('_')
+		} else {
+			writer.WriteRune(c)
 		}
-		return r
-	}, name)
+		c, _, err = reader.ReadRune()
+	}
+	return writer.String()
 }
 
 // localName returns the name for a local value with the given Terraform name.
@@ -89,9 +128,9 @@ func tsName(tfName string, tfSchema *schema.Schema, schemaInfo *tfbridge.SchemaI
 		return schemaInfo.Name
 	}
 
-	if strings.ContainsAny(tfName, " -.") {
+	if !isLegalIdentifier(tfName) {
 		if isObjectKey {
-			return fmt.Sprintf("\"%s\"", tfName)
+			return fmt.Sprintf("%q", tfName)
 		}
 		return cleanName(tfName)
 	}

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -1,0 +1,39 @@
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLegalIdentifiers(t *testing.T) {
+	legalIdentifiers := []string{
+		"foobar",
+		"$foobar",
+		"_foobar",
+		"_foo$bar",
+		"_foo1bar",
+		"Foobar",
+	}
+	for _, id := range legalIdentifiers {
+		assert.True(t, isLegalIdentifier(id))
+		assert.Equal(t, id, cleanName(id))
+	}
+
+	type illegalCase struct {
+		original string
+		expected string
+	}
+	illegalCases := []illegalCase{
+		{"123foo", "_123foo"},
+		{"foo.bar", "foo_bar"},
+		{"$foo/bar", "$foo_bar"},
+		{"12/bar\\baz", "_12_bar_baz"},
+		{"foo bar", "foo_bar"},
+		{"foo-bar", "foo_bar"},
+	}
+	for _, c := range illegalCases {
+		assert.False(t, isLegalIdentifier(c.original))
+		assert.Equal(t, c.expected, cleanName(c.original))
+	}
+}

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -31,6 +31,8 @@ func TestLegalIdentifiers(t *testing.T) {
 		{"12/bar\\baz", "_12_bar_baz"},
 		{"foo bar", "foo_bar"},
 		{"foo-bar", "foo_bar"},
+		{".bar", "_bar"},
+		{"1.bar", "_1_bar"},
 	}
 	for _, c := range illegalCases {
 		assert.False(t, isLegalIdentifier(c.original))

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -15,6 +15,7 @@
 package nodejs
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -70,6 +71,8 @@ func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 				propSch, key := n.Schemas.PropertySchemas(k), k
 				if !useExactKeys {
 					key = tsName(k, propSch.TF, propSch.Pulumi, true)
+				} else if !isLegalIdentifier(key) {
+					key = fmt.Sprintf("%q", key)
 				}
 				g.genf(w, "\n%s%s: %v,", g.indent, key, n.Elements[k])
 			}


### PR DESCRIPTION
The first cut of the code responsible for turning arbitrary TF names
into valid JavaScript identifiers was woefully incomplete. These changes
reimplement that code to confrom with the ECMA-262 spec.

Fixes #28.