### PR TITLE
Improve string literal generation

### DIFF
--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -236,8 +236,14 @@ func (g *generator) computeProperty(prop il.BoundNode, indent bool, count string
 	})
 	contract.Assert(err == nil)
 
-	// Next, rewrite assets, insert any necessary coercions, and run the apply transform.
+	// Next, rewrite assets, lower certain constructrs to literals, insert any necessary coercions, and run the apply
+	// transform.
 	p, err := il.RewriteAssets(prop)
+	if err != nil {
+		return "", false, err
+	}
+
+	p, err = g.lowerToLiterals(p)
 	if err != nil {
 		return "", false, err
 	}

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -3,7 +3,11 @@ package nodejs
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/module"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/tf2pulumi/il"
 )
 
 func TestLegalIdentifiers(t *testing.T) {
@@ -38,4 +42,55 @@ func TestLegalIdentifiers(t *testing.T) {
 		assert.False(t, isLegalIdentifier(c.original))
 		assert.Equal(t, c.expected, cleanName(c.original))
 	}
+}
+
+func TestLowerToLiteral(t *testing.T) {
+	prop := &il.BoundMapProperty{
+		Elements: map[string]il.BoundNode{
+			"key": &il.BoundOutput{
+				HILNode: nil,
+				Exprs: []il.BoundExpr{
+					&il.BoundLiteral{
+						ExprType: il.TypeString,
+						Value:    "module: ",
+					},
+					&il.BoundVariableAccess{
+						ExprType: il.TypeString,
+						TFVar:    &config.PathVariable{Type: config.PathValueModule},
+					},
+					&il.BoundLiteral{
+						ExprType: il.TypeString,
+						Value:    " root: ",
+					},
+					&il.BoundVariableAccess{
+						ExprType: il.TypeString,
+						TFVar:    &config.PathVariable{Type: config.PathValueRoot},
+					},
+				},
+			},
+		},
+	}
+
+	g := &generator{
+		rootPath: ".",
+		module:   &il.Graph{Tree: module.NewTree("foo", &config.Config{Dir: "./foo/bar"})},
+	}
+
+	p, err := g.lowerToLiterals(prop)
+	assert.NoError(t, err)
+
+	pmap := p.(*il.BoundMapProperty)
+	pout := pmap.Elements["key"].(*il.BoundOutput)
+
+	lit1, ok := pout.Exprs[1].(*il.BoundLiteral)
+	assert.True(t, ok)
+	assert.Equal(t, "foo/bar", lit1.Value)
+
+	lit3, ok := pout.Exprs[3].(*il.BoundLiteral)
+	assert.True(t, ok)
+	assert.Equal(t, ".", lit3.Value)
+
+	computed, _, err := g.computeProperty(prop, false, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "{\n    key: `module: foo/bar root: .`,\n}", computed)
 }

--- a/gen/nodejs/hil_test.go
+++ b/gen/nodejs/hil_test.go
@@ -1,0 +1,33 @@
+package nodejs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringLiteral(t *testing.T) {
+	type literalCase struct {
+		input    string
+		expected string
+	}
+
+	cases := []literalCase{
+		{"foobar", `"foobar"`},
+		{`foo"bar`, `"foo\"bar"`},
+		{`foo\bar`, `"foo\\bar"`},
+		{"foo\nbar", "`foo\nbar`"},
+		{"foo\nbar$", "`foo\nbar$`"},
+		{"foo\nbar`", "`foo\nbar\\``"},
+		{"foo\nbar\\", "`foo\nbar\\\\`"},
+		{"foo\nbar${", "`foo\nbar\\${`"},
+	}
+
+	g := &generator{}
+	for _, c := range cases {
+		b := &strings.Builder{}
+		g.genStringLiteral(b, c.input)
+		assert.Equal(t, c.expected, b.String())
+	}
+}

--- a/gen/nodejs/lower.go
+++ b/gen/nodejs/lower.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+// lowerToLiterals lowers certain elements--namely Module and Root path references--to bound literals. This allows the
+// code generator to fold these expressions into template literals as necessary.
+func (g *generator) lowerToLiterals(prop il.BoundNode) (il.BoundNode, error) {
+	rewriter := func(n il.BoundNode) (il.BoundNode, error) {
+		v, ok := n.(*il.BoundVariableAccess)
+		if !ok {
+			return n, nil
+		}
+
+		pv, ok := v.TFVar.(*config.PathVariable)
+		if !ok {
+			return n, nil
+		}
+
+		switch pv.Type {
+		case config.PathValueModule:
+			path := g.module.Tree.Config().Dir
+
+			// Attempt to make this path relative to that of the root module.
+			rel, err := filepath.Rel(g.rootPath, path)
+			if err == nil {
+				path = rel
+			}
+
+			return &il.BoundLiteral{ExprType: il.TypeString, Value: path}, nil
+		case config.PathValueRoot:
+			// NOTE: this might not be the most useful or correct value. Might want Node's __directory or similar.
+			return &il.BoundLiteral{ExprType: il.TypeString, Value: "."}, nil
+		default:
+			return n, nil
+		}
+	}
+
+	return il.VisitBoundNode(prop, il.IdentityVisitor, rewriter)
+}


### PR DESCRIPTION
Instead of generating plain string literals with escaped newlines,
generate template literals with literal newlines.

Also, lower certain path variables to bound literals prior to code
generation in order to avoid the silliness of string literals inside
interpolations in template literals.

Fixes #30.