### PR TITLE
Use cobra instead of flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1660,6 +1660,7 @@
     "github.com/pulumi/pulumi/pkg/util/contract",
     "github.com/pulumi/pulumi/pkg/util/fsutil",
     "github.com/pulumi/pulumi/pkg/workspace",
+    "github.com/spf13/cobra",
     "github.com/stretchr/testify/assert",
     "github.com/terraform-providers/terraform-provider-archive/archive",
     "github.com/terraform-providers/terraform-provider-http/http",


### PR DESCRIPTION
Some dependency is pulling in the "testing" package, which is polluting
command-line flags. These changes move the CLI over to use the "cobra"
package, which provides a better UX in general.

Fixes #52.