### PR TITLE
Statically coerce string literals to numbers

### DIFF
--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -248,7 +248,7 @@ func (g *generator) computeProperty(prop il.BoundNode, indent bool, count string
 		return "", false, err
 	}
 
-	p, err = addCoercions(p)
+	p, err = il.AddCoercions(p)
 	if err != nil {
 		return "", false, err
 	}

--- a/gen/nodejs/hil_test.go
+++ b/gen/nodejs/hil_test.go
@@ -1,9 +1,10 @@
 package nodejs
 
 import (
-	"strings"
+	"bytes"
 	"testing"
 
+	"github.com/pulumi/tf2pulumi/il"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,8 +30,56 @@ func TestStringLiteral(t *testing.T) {
 
 	g := &generator{}
 	for _, c := range cases {
-		b := &strings.Builder{}
-		g.genStringLiteral(b, c.input)
+		var b bytes.Buffer
+		g.genStringLiteral(&b, c.input)
 		assert.Equal(t, c.expected, b.String())
+	}
+}
+
+func TestNumberParseFloat(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected string
+	}
+
+	// All of these should parse successfully.
+	cases := []testCase{
+		{"123a", `123`},
+		{"+1.2", `1.2`},
+		{"42", `42`},
+		{"-42", `-42`},
+		{"3.14e0", `3.14`},
+		{"3.14E0", `3.14`},
+		{"3.", `3`},
+		{".3", `0.3`},
+		{"3.e0", `3`},
+		{".3e0", `0.3`},
+		{".314e+1", `3.14`},
+		{"31.4e-1", `3.14`},
+	}
+
+	g, b := &generator{}, &bytes.Buffer{}
+	for _, c := range cases {
+		b.Truncate(0)
+		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c.input}, il.TypeNumber)
+		assert.Equal(t, c.expected, b.String())
+
+		b.Truncate(0)
+		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c.input + "foo"}, il.TypeNumber)
+		assert.Equal(t, c.expected, b.String())
+	}
+
+	negativeCases := []string{
+		"abcd",
+		"+abcd",
+		"-abcd",
+		".abcd",
+		".e",
+		".E",
+	}
+	for _, c := range negativeCases {
+		b.Truncate(0)
+		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c}, il.TypeNumber)
+		assert.Equal(t, `NaN`, b.String())
 	}
 }

--- a/gen/nodejs/hil_test.go
+++ b/gen/nodejs/hil_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/pulumi/tf2pulumi/il"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,53 +32,5 @@ func TestStringLiteral(t *testing.T) {
 		var b bytes.Buffer
 		g.genStringLiteral(&b, c.input)
 		assert.Equal(t, c.expected, b.String())
-	}
-}
-
-func TestNumberParseFloat(t *testing.T) {
-	type testCase struct {
-		input    string
-		expected string
-	}
-
-	// All of these should parse successfully.
-	cases := []testCase{
-		{"123a", `123`},
-		{"+1.2", `1.2`},
-		{"42", `42`},
-		{"-42", `-42`},
-		{"3.14e0", `3.14`},
-		{"3.14E0", `3.14`},
-		{"3.", `3`},
-		{".3", `0.3`},
-		{"3.e0", `3`},
-		{".3e0", `0.3`},
-		{".314e+1", `3.14`},
-		{"31.4e-1", `3.14`},
-	}
-
-	g, b := &generator{}, &bytes.Buffer{}
-	for _, c := range cases {
-		b.Truncate(0)
-		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c.input}, il.TypeNumber)
-		assert.Equal(t, c.expected, b.String())
-
-		b.Truncate(0)
-		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c.input + "foo"}, il.TypeNumber)
-		assert.Equal(t, c.expected, b.String())
-	}
-
-	negativeCases := []string{
-		"abcd",
-		"+abcd",
-		"-abcd",
-		".abcd",
-		".e",
-		".E",
-	}
-	for _, c := range negativeCases {
-		b.Truncate(0)
-		g.genCoercion(b, &il.BoundLiteral{ExprType: il.TypeString, Value: c}, il.TypeNumber)
-		assert.Equal(t, `NaN`, b.String())
 	}
 }

--- a/il/coercions_test.go
+++ b/il/coercions_test.go
@@ -1,0 +1,63 @@
+package il
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringCoercions(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected interface{}
+	}
+
+	// All of these should parse successfully.
+	cases := []testCase{
+		{"", 0.0},
+		{"123", 123.0},
+		{"+1.2", 1.2},
+		{"42", 42.0},
+		{"-42", -42.0},
+		{"3.14e0", 3.14},
+		{"3.14E0", 3.14},
+		{"3.", 3.0},
+		{".3", 0.3},
+		{"3.e0", 3.0},
+		{".3e0", 0.3},
+		{".314e+1", 3.14},
+		{"31.4e-1", 3.14},
+		{"", false},
+		{"true", true},
+		{"TRUE", true},
+		{"false", false},
+		{"FALSE", false},
+	}
+
+	for _, c := range cases {
+		toType := TypeBool
+		if _, ok := c.expected.(float64); ok {
+			toType = TypeNumber
+		}
+
+		result := makeCoercion(&BoundLiteral{ExprType: TypeString, Value: c.input}, toType)
+		lit, ok := result.(*BoundLiteral)
+		assert.True(t, ok)
+		assert.Equal(t, c.expected, lit.Value)
+	}
+
+	type negativeCase struct {
+		input  string
+		toType Type
+	}
+
+	negativeCases := []negativeCase{
+		{"abcd", TypeNumber},
+		{"flase", TypeBool},
+	}
+	for _, c := range negativeCases {
+		result := makeCoercion(&BoundLiteral{ExprType: TypeString, Value: c.input}, c.toType)
+		_, ok := result.(*BoundCall)
+		assert.True(t, ok)
+	}
+}

--- a/tests/terraform/aws/lb-listener/index.base.ts
+++ b/tests/terraform/aws/lb-listener/index.base.ts
@@ -11,11 +11,11 @@ const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener("front
         throw "tf2pulumi error: aws_lb_listener.front_end.default_action: expected at most one item in list, got 2";
         return [
             {
-                authenticateCognito: [{
+                authenticateCognito: {
                     userPoolArn: __arg0,
                     userPoolClientId: __arg1,
                     userPoolDomain: __arg2,
-                }],
+                },
                 type: "authenticate-cognito",
             },
             {
@@ -25,6 +25,6 @@ const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener("front
         ];
     })()),
     loadBalancerArn: aws_lb_front_end.arn,
-    port: Number.parseFloat("80"),
+    port: 80,
     protocol: "HTTP",
 });


### PR DESCRIPTION
Implement a "good enough" version of ECMA-262's `Number.parseFloat` and
use it to statically coerce string literals to numbers where necessary.

Also, improve numeric literal generation to use only as many significant
digits as are necessary to uniquely identify the number.

Fixes #55.