### PR TITLE
Extract comments from HCL

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1644,6 +1644,8 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/hashicorp/hcl",
+    "github.com/hashicorp/hcl/hcl/ast",
     "github.com/hashicorp/hil",
     "github.com/hashicorp/hil/ast",
     "github.com/hashicorp/terraform/command",

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -80,6 +80,8 @@ type Options struct {
 	ProviderInfoSource il.ProviderInfoSource
 	// Optional logger for diagnostic information.
 	Logger *log.Logger
+	// AllowMissingComments allows binding to succeed even if there are errors extracting comments from the source.
+	AllowMissingComments bool
 }
 
 type noCredentials struct{}
@@ -105,6 +107,7 @@ func buildGraphs(tree *module.Tree, isRoot bool, opts Options) ([]*il.Graph, err
 		AllowMissingVariables: opts.AllowMissingVariables,
 		ProviderInfoSource:    opts.ProviderInfoSource,
 		Logger:                opts.Logger,
+		AllowMissingComments:  opts.AllowMissingComments,
 	}
 	g, err := il.BuildGraph(tree, &buildOpts)
 	if err != nil {

--- a/gen/nodejs/archive.go
+++ b/gen/nodejs/archive.go
@@ -113,7 +113,7 @@ func (g *generator) generateArchive(r *il.ResourceNode) error {
 		}
 
 		// Generate an asset archive.
-		g.printf("const %s = new pulumi.asset.AssetArchive(%s);\n", name, inputs)
+		g.printf("const %s = new pulumi.asset.AssetArchive(%s);", name, inputs)
 	} else {
 		// Otherwise we need to Generate multiple resources in a loop.
 		count, _, err := g.computeProperty(r.Count, false, "")
@@ -128,7 +128,7 @@ func (g *generator) generateArchive(r *il.ResourceNode) error {
 		g.printf("const %s: pulumi.asset.AssetArchive[] = [];\n", name)
 		g.printf("for (let i = 0; i < %s; i++) {\n", count)
 		g.printf("    %s.push(new pulumi.asset.AssetArchive(%s));\n", name, inputs)
-		g.printf("}\n")
+		g.printf("}")
 	}
 
 	return nil

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -1,12 +1,18 @@
 package nodejs
 
 import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/tf2pulumi/gen"
 	"github.com/pulumi/tf2pulumi/il"
 )
 
@@ -93,4 +99,186 @@ func TestLowerToLiteral(t *testing.T) {
 	computed, _, err := g.computeProperty(prop, false, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "{\n    key: `module: foo/bar root: .`,\n}", computed)
+}
+
+func TestComments(t *testing.T) {
+	const hclText = `
+# Accept the AWS region as input.
+variable "aws_region" {
+	# Default to us-west-2
+	default = "us-west-2"
+}
+
+/*
+Specify provider details
+*/
+provider "aws" {
+	# Pull the region from a variable
+    region = "${var.aws_region}"
+}
+
+# Create a VPC.
+#
+# Note that the VPC has been tagged appropriately.
+resource "aws_vpc" "default" {
+    cidr_block = "10.0.0.0/16"  # Just one CIDR block
+	enable_dns_hostnames = true # Definitely want DNS hostnames.
+
+	# The tag collection for this VPC.
+	tags {
+		# Ensure that we tag this VPC with a Name.
+		Name = "test"
+	}
+}
+
+locals {
+	# The VPC details
+	vpc = {
+		# The ID
+		id = "${aws_vpc.default.id}"
+	}
+
+	# The region, again
+	region = "${var.aws_region}" // why not
+}
+
+// Create a security group.
+//
+// This group should allow SSH and HTTP access.
+resource "aws_security_group" "default" {
+	vpc_id = "${locals.vpc_id.id}"
+
+	// SSH access from anywhere
+	ingress {
+		from_port   = 22
+		to_port     = 22
+		protocol    = "tcp"
+		// "0.0.0.0/0" is anywhere
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	// HTTP access from anywhere
+	ingress {
+		from_port   = 80
+		to_port     = 80
+		protocol    = "tcp" /* HTTP is TCP-only */
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	// outbound internet access
+	egress {
+		from_port   = 0
+		to_port     = 0
+		protocol    = "-1" // All
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+}
+
+/**
+ * Output the SG name.
+ *
+ * We pull the name from the default SG.
+ */
+output "security_group_name" {
+	/* Take the value from the default SG. */
+	value = "${aws_security_group.default.name}" # Neat!
+}
+`
+
+	const expectedText = `import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// Accept the AWS region as input.
+const var_aws_region = config.get("awsRegion") || "us-west-2";
+
+// Create a security group.
+//
+// This group should allow SSH and HTTP access.
+const aws_security_group_default = new aws.ec2.SecurityGroup("default", {
+    // outbound internet access
+    egress: [{
+        cidrBlocks: ["0.0.0.0/0"],
+        fromPort: 0,
+        protocol: "-1", // All
+        toPort: 0,
+    }],
+    ingress: [
+        // SSH access from anywhere
+        {
+            // "0.0.0.0/0" is anywhere
+            cidrBlocks: ["0.0.0.0/0"],
+            fromPort: 22,
+            protocol: "tcp",
+            toPort: 22,
+        },
+        // HTTP access from anywhere
+        {
+            cidrBlocks: ["0.0.0.0/0"],
+            fromPort: 80,
+            protocol: "tcp", // HTTP is TCP-only
+            toPort: 80,
+        },
+    ],
+    vpcId: locals_vpc_id.id,
+});
+// Create a VPC.
+//
+// Note that the VPC has been tagged appropriately.
+const aws_vpc_default = new aws.ec2.Vpc("default", {
+    cidrBlock: "10.0.0.0/16", // Just one CIDR block
+    enableDnsHostnames: true, // Definitely want DNS hostnames.
+    // The tag collection for this VPC.
+    tags: {
+        // Ensure that we tag this VPC with a Name.
+        Name: "test",
+    },
+});
+// The region, again
+const local_region = var_aws_region; // why not
+// The VPC details
+const local_vpc = [{
+    // The ID
+    id: aws_vpc_default.id,
+}];
+
+// Output the SG name.
+//
+// We pull the name from the default SG.
+// Take the value from the default SG.
+export const securityGroupName = aws_security_group_default.name; // Neat!
+`
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("could not create temporary directory: %v", err)
+	}
+	defer func() {
+		contract.IgnoreError(os.RemoveAll(dir))
+	}()
+
+	err = ioutil.WriteFile(path.Join(dir, "main.tf"), []byte(hclText), 0600)
+	if err != nil {
+		t.Fatalf("could not create main.tf: %v", err)
+	}
+
+	conf, err := config.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("could not load config: %v", err)
+	}
+
+	g, err := il.BuildGraph(module.NewTree("main", conf), &il.BuildOptions{
+		AllowMissingProviders: true,
+		AllowMissingVariables: true,
+		AllowMissingComments:  true,
+	})
+	if err != nil {
+		t.Fatalf("could not build graph: %v", err)
+	}
+
+	var b bytes.Buffer
+	err = gen.Generate([]*il.Graph{g}, New("main", &b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedText, b.String())
 }

--- a/gen/nodejs/http.go
+++ b/gen/nodejs/http.go
@@ -66,7 +66,7 @@ func (g *generator) generateHTTP(r *il.ResourceNode) error {
 			return err
 		}
 
-		g.printf("const %s = pulumi.output(rpn(%s).promise());\n", name, inputs)
+		g.printf("const %s = pulumi.output(rpn(%s).promise());", name, inputs)
 	} else {
 		count, _, err := g.computeProperty(r.Count, false, "")
 		if err != nil {
@@ -80,7 +80,7 @@ func (g *generator) generateHTTP(r *il.ResourceNode) error {
 		g.printf("const %s: pulumi.Output<string>[] = [];\n", name)
 		g.printf("for (let i = 0; i < %s; i++) {\n", count)
 		g.printf("    %s.push(pulumi.output(rpn(%s).promise()));\n", name, inputs)
-		g.printf("}\n")
+		g.printf("}")
 	}
 
 	return nil

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -47,9 +47,7 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 		g.indented(func() {
 			for _, v := range n.Elements {
 				g.genf(w, "\n")
-				if v.Comments() != nil {
-					g.genComment(w, v.Comments().Leading)
-				}
+				g.genLeadingComment(w, v.Comments())
 				g.genf(w, "%s", g.indent)
 
 				// TF flattens list elements that are themselves lists into the parent list.
@@ -60,6 +58,8 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 					g.gen(w, "...")
 				}
 				g.genf(w, "%v,", v)
+
+				g.genTrailingComment(w, v.Comments())
 			}
 		})
 		g.gen(w, "\n", g.indent, "]")
@@ -79,9 +79,7 @@ func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 				v := n.Elements[k]
 
 				g.genf(w, "\n")
-				if v.Comments() != nil {
-					g.genComment(w, v.Comments().Leading)
-				}
+				g.genLeadingComment(w, v.Comments())
 
 				propSch, key := n.Schemas.PropertySchemas(k), k
 				if !useExactKeys {
@@ -90,6 +88,8 @@ func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 					key = fmt.Sprintf("%q", key)
 				}
 				g.genf(w, "%s%s: %v,", g.indent, key, v)
+
+				g.genTrailingComment(w, v.Comments())
 			}
 		})
 		g.gen(w, "\n", g.indent, "}")

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -30,6 +30,8 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 	case 0:
 		g.gen(w, "[]")
 	case 1:
+		// We can ignore comments in this case: the comment extractor will never associate comments with a
+		// single-element list.
 		v := n.Elements[0]
 		if v.Type().IsList() {
 			// TF flattens list elements that are themselves lists into the parent list.
@@ -44,6 +46,12 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 		g.gen(w, "[")
 		g.indented(func() {
 			for _, v := range n.Elements {
+				g.genf(w, "\n")
+				if v.Comments() != nil {
+					g.genComment(w, v.Comments().Leading)
+				}
+				g.genf(w, "%s", g.indent)
+
 				// TF flattens list elements that are themselves lists into the parent list.
 				//
 				// TODO: if there is a list element that is dynamically a list, that also needs to be flattened. This is
@@ -51,7 +59,7 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 				if v.Type().IsList() {
 					g.gen(w, "...")
 				}
-				g.genf(w, "\n%s%v,", g.indent, v)
+				g.genf(w, "%v,", v)
 			}
 		})
 		g.gen(w, "\n", g.indent, "]")
@@ -68,13 +76,20 @@ func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 		g.gen(w, "{")
 		g.indented(func() {
 			for _, k := range gen.SortedKeys(n.Elements) {
+				v := n.Elements[k]
+
+				g.genf(w, "\n")
+				if v.Comments() != nil {
+					g.genComment(w, v.Comments().Leading)
+				}
+
 				propSch, key := n.Schemas.PropertySchemas(k), k
 				if !useExactKeys {
 					key = tsName(k, propSch.TF, propSch.Pulumi, true)
 				} else if !isLegalIdentifier(key) {
 					key = fmt.Sprintf("%q", key)
 				}
-				g.genf(w, "\n%s%s: %v,", g.indent, key, n.Elements[k])
+				g.genf(w, "%s%s: %v,", g.indent, key, v)
 			}
 		})
 		g.gen(w, "\n", g.indent, "}")

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -130,10 +130,23 @@ func (d *dumper) dump(vs ...interface{}) {
 	}
 }
 
+// Comments represents the set of comments associated with a node.
+type Comments struct {
+	// Leading is the lines of the comment (sans comment tokens) that precedes a node, if any. Line endings (if any)
+	// are present.
+	Leading []string
+	// Trailing is the lines of the comment (sans comment tokens) that succeeds a node, if any. Line ending (if any)
+	// are present.
+	Trailing []string
+}
+
 // A BoundNode represents a single bound property map, property list, or interpolation expression. Every
 // BoundNode has a Type.
 type BoundNode interface {
+	commentable
+
 	Type() Type
+	Comments() *Comments
 
 	dump(d *dumper)
 	isNode()
@@ -151,6 +164,8 @@ type BoundExpr interface {
 type BoundArithmetic struct {
 	// HILNode is the HIL node associated with this arithmetic expression.
 	HILNode *ast.Arithmetic
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Exprs is the bound list of the arithmetic expression's operands.
 	Exprs []BoundExpr
 }
@@ -158,6 +173,16 @@ type BoundArithmetic struct {
 // Type returns the type of the arithmetic expression, which is always TypeNumber.
 func (n *BoundArithmetic) Type() Type {
 	return TypeNumber
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundArithmetic) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundArithmetic) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundArithmetic) dump(d *dumper) {
@@ -177,6 +202,8 @@ func (n *BoundArithmetic) isExpr() {}
 type BoundCall struct {
 	// HILNode is the HIL node associated with this call.
 	HILNode *ast.Call
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// ExprType is the type of the call expression.
 	ExprType Type
 	// Args is the bound list of the call's arguments.
@@ -186,6 +213,16 @@ type BoundCall struct {
 // Type returns the type of the call expression.
 func (n *BoundCall) Type() Type {
 	return n.ExprType
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundCall) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundCall) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundCall) dump(d *dumper) {
@@ -205,6 +242,8 @@ func (n *BoundCall) isExpr() {}
 type BoundConditional struct {
 	// HILNode is the HIL node associated with this conditional expression.
 	HILNode *ast.Conditional
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// ExprType is the type of the conditional expression.
 	ExprType Type
 	// CondExpr is the bound form of the conditional expression's predicate.
@@ -218,6 +257,16 @@ type BoundConditional struct {
 // Type returns the type of the conditional expression.
 func (n *BoundConditional) Type() Type {
 	return n.ExprType
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundConditional) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundConditional) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundConditional) dump(d *dumper) {
@@ -237,6 +286,8 @@ func (n *BoundConditional) isExpr() {}
 type BoundIndex struct {
 	// HILNode is the HIL node associated with this index expression.
 	HILNode *ast.Index
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// ExprType is the type of the index expression.
 	ExprType Type
 	// TargetExpr is the bound form of the index expression's target (e.g. `foo` in `${foo[bar]}`).
@@ -248,6 +299,16 @@ type BoundIndex struct {
 // Type returns the type of the index expression.
 func (n *BoundIndex) Type() Type {
 	return n.ExprType
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundIndex) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundIndex) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundIndex) dump(d *dumper) {
@@ -266,6 +327,8 @@ func (n *BoundIndex) isExpr() {}
 type BoundLiteral struct {
 	// ExprType is the type of the literal expression.
 	ExprType Type
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Value is the value of the literal expression. This may be a bool, string, float64, or in the case of the
 	// argument to the __applyArg intrinsic, an int.
 	Value interface{}
@@ -274,6 +337,16 @@ type BoundLiteral struct {
 // Type returns the type of the literal expression.
 func (n *BoundLiteral) Type() Type {
 	return n.ExprType
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundLiteral) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundLiteral) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundLiteral) dump(d *dumper) {
@@ -292,6 +365,8 @@ func (n *BoundLiteral) isExpr() {}
 type BoundOutput struct {
 	// HILNode is the HIL node associated with this output expression.
 	HILNode *ast.Output
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Exprs is the bound list of the output's operands.
 	Exprs []BoundExpr
 }
@@ -299,6 +374,16 @@ type BoundOutput struct {
 // Type returns the type of the output expression (which is always TypeString).
 func (n *BoundOutput) Type() Type {
 	return TypeString
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundOutput) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundOutput) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundOutput) dump(d *dumper) {
@@ -318,6 +403,8 @@ func (n *BoundOutput) isExpr() {}
 type BoundVariableAccess struct {
 	// HILNode is the HIL node associated with this variable access expression.
 	HILNode *ast.VariableAccess
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Elements are the path elements that comprise the variable access expression.
 	Elements []string
 	// Schemas are the Terraform and Pulumi schemas associated with the referenced variable.
@@ -335,6 +422,16 @@ func (n *BoundVariableAccess) Type() Type {
 	return n.ExprType
 }
 
+// Comments returns the comments attached to this node, if any.
+func (n *BoundVariableAccess) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundVariableAccess) setComments(c *Comments) {
+	n.NodeComments = c
+}
+
 func (n *BoundVariableAccess) dump(d *dumper) {
 	d.dump(fmt.Sprintf("(%s %s %T)", n.HILNode.Name, n.Type(), n.TFVar))
 }
@@ -348,6 +445,8 @@ func (n *BoundVariableAccess) IsMissingVariable() bool {
 
 // BoundListProperty is the bound form of an HCL list property. (e.g. `[ foo, bar ]`).
 type BoundListProperty struct {
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Schemas are the Terraform and Pulumi schemas associated with the list.
 	Schemas Schemas
 	// Elements is the bound list of the list's elements.
@@ -357,6 +456,16 @@ type BoundListProperty struct {
 // Type returns the type of the list property (always a list type).
 func (n *BoundListProperty) Type() Type {
 	return n.Schemas.ElemSchemas().Type().ListOf()
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundListProperty) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundListProperty) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundListProperty) dump(d *dumper) {
@@ -377,6 +486,8 @@ func (n *BoundListProperty) isNode() {}
 
 // BoundMapProperty is the bound form of an HCL map property. (e.g. `{ foo = bar ]`).
 type BoundMapProperty struct {
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// Schemas are the Terraform and Pulumi schemas associated with the map.
 	Schemas Schemas
 	// Elements is a map from name to bound value of the map's elements.
@@ -386,6 +497,16 @@ type BoundMapProperty struct {
 // Type returns the type of the map property (always TypeMap).
 func (n *BoundMapProperty) Type() Type {
 	return TypeMap
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundMapProperty) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundMapProperty) setComments(c *Comments) {
+	n.NodeComments = c
 }
 
 func (n *BoundMapProperty) dump(d *dumper) {
@@ -409,6 +530,8 @@ func (n *BoundMapProperty) isNode() {}
 type BoundError struct {
 	// The type of the node.
 	NodeType Type
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
 	// A bound node (if any) associated with this error
 	Value BoundNode
 	// The binding error
@@ -420,15 +543,25 @@ func (n *BoundError) Type() Type {
 	return n.NodeType
 }
 
+// Comments returns the comments attached to this node, if any.
+func (n *BoundError) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundError) setComments(c *Comments) {
+	n.NodeComments = c
+}
+
 func (n *BoundError) dump(d *dumper) {
 	d.dump("(error ", fmt.Sprintf("%v", n.Type()))
 	if n.Value != nil {
 		d.indented(func() {
-			d.dump("\n", n.Value)
+			d.dump("\n", d.indent, n.Value)
 		})
 		d.dump("\n", d.indent)
 	}
-	d.dump("\"%q\")", n.Error.Error())
+	d.dump(d.indent, fmt.Sprintf("%q)", n.Error.Error()))
 }
 
 func (n *BoundError) isNode() {}

--- a/il/graph_comments.go
+++ b/il/graph_comments.go
@@ -1,0 +1,289 @@
+package il
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/terraform/config"
+)
+
+// commentable is an interface shared by the IL's top-level nodes (e.g. ResourceNode, OutputNode) and its bound
+// nodes.
+type commentable interface {
+	setComments(c *Comments)
+}
+
+// extractComments annotates the builder's nodes with comments extracted from the given config's HCL sources. This
+// is a best-effort process: not all comments are extractable due to weaknesses in the HCL parser. This process will
+// only fail if files are unreadable or unparseable.
+func (b *builder) extractComments(c *config.Config) error {
+	// Nothing we can do if `Dir` is empty.
+	if c.Dir == "" {
+		return nil
+	}
+
+	// Find all config and/or override files in the directory.
+	files, err := ioutil.ReadDir(c.Dir)
+	if err != nil {
+		return err
+	}
+	var configs, overrides []string
+	for _, f := range files {
+		if f.IsDir() || config.IsIgnoredFile(f.Name()) || !strings.HasSuffix(f.Name(), ".tf") {
+			continue
+		}
+
+		// Check to see if the file is an override.
+		if n := f.Name()[:len(f.Name())-len(".tf")]; n == "override" || strings.HasSuffix(n, "_override") {
+			overrides = append(overrides, f.Name())
+		} else {
+			configs = append(configs, f.Name())
+		}
+	}
+
+	for _, f := range configs {
+		if err := b.extractFileComments(path.Join(c.Dir, f)); err != nil {
+			return err
+		}
+	}
+	for _, f := range overrides {
+		if err := b.extractFileComments(path.Join(c.Dir, f)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractFileComments extracts comments from a particular HCL source file.
+func (b *builder) extractFileComments(path string) error {
+	t, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	f, err := hcl.ParseBytes(t)
+	if err != nil {
+		return err
+	}
+
+	b.extractHCLComments(f)
+	return nil
+}
+
+// extractHCLComments extracts comments from the given HCL file.
+func (b *builder) extractHCLComments(f *ast.File) {
+	root, ok := f.Node.(*ast.ObjectList)
+	if !ok {
+		return
+	}
+
+	// Extract variable comments
+	for _, n := range root.Items {
+		switch n.Keys[0].Token.Value().(string) {
+		case "variable":
+			b.extractVariableComments(n)
+		case "provider":
+			b.extractProviderComments(n)
+		case "module":
+			b.extractModuleComments(n)
+		case "resource":
+			b.extractResourceComments(n, config.ManagedResourceMode)
+		case "data":
+			b.extractResourceComments(n, config.DataResourceMode)
+		case "locals":
+			if object, ok := n.Val.(*ast.ObjectType); ok {
+				for _, ln := range object.List.Items {
+					b.extractLocalComments(ln)
+				}
+			}
+		case "output":
+			b.extractOutputComments(n)
+		}
+	}
+}
+
+// extractVariableComments extracts comments from the given HCL object item and attaches them to the corresponding
+// variable node, if any exists.
+func (b *builder) extractVariableComments(item *ast.ObjectItem) {
+	name := item.Keys[1].Token.Value().(string)
+	v, ok := b.variables[name]
+	if !ok {
+		return
+	}
+
+	attachComments(v, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, &BoundMapProperty{Elements: map[string]BoundNode{"default": v.DefaultValue}})
+}
+
+// extractProviderComments extracts comments from the given HCL object item and attaches them to the corresponding
+// provider node, if any exists.
+func (b *builder) extractProviderComments(item *ast.ObjectItem) {
+	name := item.Keys[1].Token.Value().(string)
+	p, ok := b.providers[name]
+	if !ok {
+		return
+	}
+
+	attachComments(p, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, p.Properties)
+}
+
+// extractModuleComments extracts comments from the given HCL object item and attaches them to the corresponding
+// module node, if any exists.
+func (b *builder) extractModuleComments(item *ast.ObjectItem) {
+	name := item.Keys[1].Token.Value().(string)
+	m, ok := b.modules[name]
+	if !ok {
+		return
+	}
+
+	attachComments(m, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, m.Properties)
+}
+
+// extractResourceComments extracts comments from the given HCL object item and attaches them to the corresponding
+// resource node, if any exists.
+func (b *builder) extractResourceComments(item *ast.ObjectItem, mode config.ResourceMode) {
+	cfg := &config.Resource{
+		Mode: mode,
+		Name: item.Keys[2].Token.Value().(string),
+		Type: item.Keys[1].Token.Value().(string),
+	}
+	r, ok := b.resources[cfg.Id()]
+	if !ok {
+		return
+	}
+
+	attachComments(r, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, r.Properties)
+}
+
+// extractLocalComments extracts comments from the given HCL object item and attaches them to the corresponding
+// local node, if any exists.
+func (b *builder) extractLocalComments(item *ast.ObjectItem) {
+	name := item.Keys[0].Token.Value().(string)
+	l, ok := b.locals[name]
+	if !ok {
+		return
+	}
+
+	attachComments(l, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, l.Value)
+}
+
+// extractOutputComments extracts comments from the given HCL object item and attaches them to the corresponding
+// output node, if any exists.
+func (b *builder) extractOutputComments(item *ast.ObjectItem) {
+	name := item.Keys[1].Token.Value().(string)
+	o, ok := b.outputs[name]
+	if !ok {
+		return
+	}
+
+	attachComments(o, item.LeadComment, item.LineComment)
+	b.extractNodeComments(item.Val, &BoundMapProperty{Elements: map[string]BoundNode{"value": o.Value}})
+}
+
+// extractNodeComments recursively extracts comments from the given HCL AST node and attaches them to the appropriate
+// piece of the given context. Currently this only operates on list and object nodes and their elements.
+func (b *builder) extractNodeComments(node ast.Node, context BoundNode) {
+	switch node := node.(type) {
+	case *ast.ListType:
+		prop, ok := context.(*BoundListProperty)
+		if !ok {
+			return
+		}
+		for i, item := range node.List {
+			element := prop.Elements[i]
+			if literal, ok := item.(*ast.LiteralType); ok {
+				attachComments(element, literal.LeadComment, literal.LineComment)
+			} else {
+				b.extractNodeComments(item, element)
+			}
+		}
+	case *ast.ObjectType:
+		// TF does some very strange things when it comes to wrapping objects in lists.
+		if list, ok := context.(*BoundListProperty); ok && len(list.Elements) == 1 {
+			context = list.Elements[0]
+		}
+		prop, ok := context.(*BoundMapProperty)
+		if !ok {
+			return
+		}
+
+		objectItems := make(map[string][]*ast.ObjectItem)
+		for _, item := range node.List.Items {
+			key := item.Keys[0].Token.Value().(string)
+			objectItems[key] = append(objectItems[key], item)
+		}
+
+		for key, items := range objectItems {
+			element, ok := prop.Elements[key]
+			if !ok {
+				continue
+			}
+
+			if len(items) == 1 {
+				// If there is only one item for a key, we associate its comments with the element itself.
+				item := items[0]
+				attachComments(element, item.LeadComment, item.LineComment)
+				b.extractNodeComments(item.Val, element)
+			} else if list, ok := element.(*BoundListProperty); ok && len(items) == len(list.Elements) {
+				// If there are mutiple items for a key and they correspond to a list property, attempt to associate
+				// each item's comments with its corresponding list element.
+				for i, item := range items {
+					element = list.Elements[i]
+					attachComments(element, item.LeadComment, item.LineComment)
+					b.extractNodeComments(item.Val, element)
+				}
+			} else {
+				// This is a strange case: we have multiple items with the same key in the object, but the
+				// corresponding property is not a list or differs in length. Log it and carry on.
+				b.logf("list mismatch for key '%v': %v, %T", key, len(items), element)
+			}
+		}
+	case *ast.LiteralType:
+		// We only encounter this case when recursing on the value associated with an object item. In this case, the
+		// literal itself has no associated comments, as they are stored on the object item.
+	default:
+		b.logf("unhandled ast type %T (%v)", node, node)
+	}
+}
+
+// attachComments preprocesses the given leading and trailing comments (if any) and attaches them to the given node.
+func attachComments(n commentable, leading, trailing *ast.CommentGroup) {
+	c := Comments{
+		Leading:  extractComment(leading),
+		Trailing: extractComment(trailing),
+	}
+	if len(c.Leading) != 0 || len(c.Trailing) != 0 {
+		n.setComments(&c)
+	}
+}
+
+// extractComment separates the given comment into lines and attempts to remove comment tokens.
+func extractComment(g *ast.CommentGroup) []string {
+	if g == nil {
+		return nil
+	}
+
+	var lines []string
+	for _, c := range g.List {
+		// Strip leading comment tokens.
+		comment := c.Text
+		switch {
+		case comment[0] == '#':
+			comment = comment[1:]
+		case comment[0:2] == "//":
+			comment = comment[2:]
+		case comment[0:2] == "/*":
+			// This is more complex, stripping these characters can often lead to strange alignment, and these comments
+			// are relatively rare, so we leave them as-is.
+		}
+		lines = append(lines, strings.Split(comment, "\n")...)
+	}
+	return lines
+}

--- a/il/graph_comments_test.go
+++ b/il/graph_comments_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package il
 
 import (

--- a/il/graph_comments_test.go
+++ b/il/graph_comments_test.go
@@ -1,0 +1,154 @@
+package il
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertLeading(t *testing.T, c *Comments, expected ...string) {
+	assert.Equal(t, expected, c.Leading)
+}
+
+func TestExtractComments(t *testing.T) {
+	const hclText = `
+# Accept the AWS region as input.
+variable "aws_region" {
+	# Default to us-west-2
+	default = "us-west-2"
+}
+
+# Specify provider details
+provider "aws" {
+	# Pull the region from a variable
+    region = "${var.aws_region}"
+}
+
+# Create a VPC.
+#
+# Note that the VPC has been tagged appropriately.
+resource "aws_vpc" "default" {
+    cidr_block = "10.0.0.0/16"
+	enable_dns_hostnames = true
+
+	# The tag collection for this VPC.
+	tags {
+		# Ensure that we tag this VPC with a Name.
+		Name = "test"
+	}
+}
+
+locals {
+	# The VPC details
+	vpc = {
+		# The ID
+		id = "${aws_vpc.default.id}"
+	}
+}
+
+// Create a security group.
+//
+// This group should allow SSH and HTTP access.
+resource "aws_security_group" "default" {
+	vpc_id = "${locals.vpc_id.id}"
+
+	// SSH access from anywhere
+	ingress {
+		from_port   = 22
+		to_port     = 22
+		protocol    = "tcp"
+		// "0.0.0.0/0" is anywhere
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	// HTTP access from anywhere
+	ingress {
+		from_port   = 80
+		to_port     = 80
+		protocol    = "tcp"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	// outbound internet access
+	egress {
+		from_port   = 0
+		to_port     = 0
+		protocol    = "-1"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+}
+
+# Output the SG name.
+output "security_group_name" {
+	# Take the value from the default SG.
+	value = "${aws_security_group.default.name}"
+}
+`
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("could not create temporary directory: %v", err)
+	}
+	defer func() {
+		contract.IgnoreError(os.RemoveAll(dir))
+	}()
+
+	err = ioutil.WriteFile(path.Join(dir, "main.tf"), []byte(hclText), 0600)
+	if err != nil {
+		t.Fatalf("could not create main.tf: %v", err)
+	}
+
+	conf, err := config.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("could not load config: %v", err)
+	}
+
+	b := newBuilder(&BuildOptions{
+		AllowMissingProviders: true,
+		AllowMissingVariables: true,
+		AllowMissingComments:  true,
+	})
+	err = b.buildNodes(conf)
+	assert.NoError(t, err)
+
+	err = b.extractComments(conf)
+	assert.NoError(t, err)
+
+	v := b.variables["aws_region"]
+	assertLeading(t, v.Comments, " Accept the AWS region as input.")
+	assertLeading(t, v.DefaultValue.Comments(), " Default to us-west-2")
+
+	p := b.providers["aws"]
+	assertLeading(t, p.Comments, " Specify provider details")
+	assertLeading(t, p.Properties.Elements["region"].Comments(), " Pull the region from a variable")
+
+	l := b.locals["vpc"]
+	assertLeading(t, l.Comments, " The VPC details")
+	lval := l.Value.(*BoundListProperty).Elements[0].(*BoundMapProperty)
+	assertLeading(t, lval.Elements["id"].Comments(), " The ID")
+
+	vpc := b.resources["aws_vpc.default"]
+	assertLeading(t, vpc.Comments, " Create a VPC.", "", " Note that the VPC has been tagged appropriately.")
+	tagsProp := vpc.Properties.Elements["tags"].(*BoundMapProperty)
+	assertLeading(t, tagsProp.Comments(), " The tag collection for this VPC.")
+	assertLeading(t, tagsProp.Elements["Name"].Comments(), " Ensure that we tag this VPC with a Name.")
+
+	sg := b.resources["aws_security_group.default"]
+	assertLeading(t, sg.Comments, " Create a security group.", "", " This group should allow SSH and HTTP access.")
+	ingressList := sg.Properties.Elements["ingress"].(*BoundListProperty)
+	sshAccess := ingressList.Elements[0].(*BoundMapProperty)
+	assertLeading(t, sshAccess.Comments(), " SSH access from anywhere")
+	assertLeading(t, sshAccess.Elements["cidr_blocks"].Comments(), ` "0.0.0.0/0" is anywhere`)
+	assertLeading(t, ingressList.Elements[1].Comments(), " HTTP access from anywhere")
+	egressList := sg.Properties.Elements["egress"].(*BoundListProperty)
+	assertLeading(t, egressList.Comments(), " outbound internet access")
+
+	out := b.outputs["security_group_name"]
+	assertLeading(t, out.Comments, " Output the SG name.")
+	assertLeading(t, out.Value.Comments(), " Take the value from the default SG.")
+}

--- a/main.go
+++ b/main.go
@@ -46,11 +46,13 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"allows code generation to continue if resource provider plugins are missing")
 	flag.BoolVar(&opts.AllowMissingVariables, "allow-missing-variables", false,
 		"allows code generation to continue if the config references missing variables")
+	flag.BoolVar(&opts.AllowMissingComments, "allow-missing-comments", true,
+		"allows code generation to continue if there are errors extracting comments")
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of tf2pulumi",
-		Long:  `All software has versions. This is tf2pulumi's`,
+		Long:  `All software has versions. This is tf2pulumi's.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version.Version)
 		},


### PR DESCRIPTION
These changes implement basic extraction of comments from a module's HCL
source file. Any IL node may have leading and trailing comments attached
to it. The NodeJS generator has been updated to convert leading comments
for all top-level entities and map and list elements.

Fixes #34.