### PR TITLE
Improve top-level name generation

### DIFF
--- a/gen/nodejs/archive.go
+++ b/gen/nodejs/archive.go
@@ -104,7 +104,7 @@ func (g *generator) generateArchive(r *il.ResourceNode) error {
 
 	// TODO: explicit dependencies (or any dependencies at all, really)
 
-	name := resName(r.Config.Type, r.Config.Name)
+	name := g.nodeName(r)
 
 	if r.Count == nil {
 		inputs, err := g.computeArchiveInputs(r, false, "")

--- a/gen/nodejs/assign_names.go
+++ b/gen/nodejs/assign_names.go
@@ -20,6 +20,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/hashicorp/terraform/config"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/tf2pulumi/gen"
 	"github.com/pulumi/tf2pulumi/il"
@@ -156,6 +157,11 @@ func (nt *nameTable) disambiguateResourceName(n *il.ResourceNode) string {
 		return cleanName(n.Config.Type + "_" + n.Config.Name)
 	}
 	packageName, moduleName = title(packageName), title(moduleName)
+
+	// If we're dealing with a data source, strip any leading "get" from the typeName.
+	if n.Config.Mode == config.DataResourceMode && strings.HasPrefix(typeName, "get") {
+		typeName = typeName[len("get"):]
+	}
 
 	// First attempt to disambiguate by appending the NodeJS resource type.
 	root := name

--- a/gen/nodejs/assign_names.go
+++ b/gen/nodejs/assign_names.go
@@ -82,7 +82,7 @@ func (nt *nameTable) tsName(name string) (string, bool) {
 // disambiguate ensures that the given name is unambiguous by appending an integer starting with 1 if necessary.
 func (nt *nameTable) disambiguate(name string) string {
 	root := name
-	for i := 1; nt.assigned[name]; {
+	for i := 1; nt.assigned[name]; i++ {
 		name = fmt.Sprintf("%s%d", root, i)
 	}
 	return name

--- a/gen/nodejs/assign_names.go
+++ b/gen/nodejs/assign_names.go
@@ -1,0 +1,232 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+type nameTable struct {
+	names        map[il.Node]string
+	assigned     map[string]bool
+	isRootModule bool
+}
+
+// isReservedWord returns true if s is a reserved word as per ECMA-262.
+func isReservedWord(s string) bool {
+	switch s {
+	case "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
+		"do", "else", "export", "extends", "finally", "for", "function", "if", "import",
+		"in", "instanceof", "new", "return", "super", "switch", "this", "throw", "try",
+		"typeof", "var", "void", "while", "with", "yield":
+		// Keywords
+		return true
+
+	case "enum", "await", "implements", "interface", "package", "private", "protected", "public":
+		// Future reserved words
+		return true
+
+	case "null", "true", "false":
+		// Null and boolean literals
+		return true
+
+	default:
+		return false
+	}
+}
+
+// title replaces the first character in the given string with its upper-case equivalent.
+func title(s string) string {
+	c, sz := utf8.DecodeRuneInString(s)
+	if sz == 0 || unicode.IsUpper(c) {
+		return s
+	}
+	return string([]rune{unicode.ToUpper(c)}) + s[sz:]
+}
+
+// camel replaces the first character in the given string with its lower-case equivalent.
+func camel(s string) string {
+	c, sz := utf8.DecodeRuneInString(s)
+	if sz == 0 || unicode.IsLower(c) {
+		return s
+	}
+	return string([]rune{unicode.ToLower(c)}) + s[sz:]
+}
+
+// tsName computes the TypeScript form of the given name.
+func (nt *nameTable) tsName(name string) (string, bool) {
+	n := camel(tsName(name, nil, nil, false))
+	return n, isReservedWord(n)
+}
+
+// disambiguate ensures that the given name is unambiguous by appending an integer starting with 1 if necessary.
+func (nt *nameTable) disambiguate(name string) string {
+	root := name
+	for i := 1; nt.assigned[name]; {
+		name = fmt.Sprintf("%s%d", root, i)
+	}
+	return name
+}
+
+// assignOutput assigns an unambiguous name to an output node.
+func (nt *nameTable) assignOutput(n *il.OutputNode) {
+	// We use the global tsName function here so that we can pass an argument for isObjectKey.
+	name := tsName(n.Config.Name, nil, nil, !nt.isRootModule)
+	contract.Assert(!nt.assigned[name])
+
+	nt.names[n] = name
+
+	// Outputs do not share the same namespace as other nodes if we are generating a child module.
+	if nt.isRootModule {
+		nt.assigned[name] = true
+	}
+}
+
+// assignLocal assigns an unambiguous name to a local node.
+func (nt *nameTable) assignLocal(n *il.LocalNode) {
+	name, isReserved := nt.tsName(n.Config.Name)
+
+	// If the raw name is reserved or ambiguous, first attempt to disambiguate by prepending "my".
+	if isReserved || nt.assigned[name] {
+		name = nt.disambiguate("my" + strings.Title(name))
+	}
+
+	nt.names[n], nt.assigned[name] = name, true
+}
+
+// assignVariable assigns an unambiguous name to a variable node.
+func (nt *nameTable) assignVariable(n *il.VariableNode) {
+	name, isReserved := nt.tsName(n.Config.Name)
+
+	// If the raw name is reserved or ambiguous, first attempt to disambiguate by appending "Input".
+	if isReserved || nt.assigned[name] {
+		name = nt.disambiguate(name + "Input")
+	}
+
+	nt.names[n], nt.assigned[name] = name, true
+}
+
+// assignModule assigns an unambiguous name to a module node.
+func (nt *nameTable) assignModule(n *il.ModuleNode) {
+	name, isReserved := nt.tsName(n.Config.Name)
+
+	// If the raw name is ambiguous, first attempt to disambiguate by appending "Instance"
+	if isReserved || nt.assigned[name] {
+		name = nt.disambiguate(name + "Instance")
+	}
+
+	nt.names[n], nt.assigned[name] = name, true
+}
+
+// disambiguateResourceName computes an unambiguous name for the given resource node.
+func (nt *nameTable) disambiguateResourceName(n *il.ResourceNode) string {
+	name, isReserved := nt.tsName(n.Config.Name)
+
+	if len(name) == 1 {
+		// If the name is a single character, ignore it and fall through to the disambiguator.
+		name = ""
+	} else if name != "" && !isReserved && !nt.assigned[name] {
+		// If the name is not reserved and is unambiguous, use it.
+		return name
+	}
+
+	// Determine the resource's NodeJS package, module, and type name. These will be used during the disambiguation
+	// process. If these names cannot be determined, return an ugly name comprised of the TF type and name.
+	packageName, moduleName, typeName, err := resourceTypeName(n)
+	if err != nil {
+		return cleanName(n.Config.Type + "_" + n.Config.Name)
+	}
+	packageName, moduleName = title(packageName), title(moduleName)
+
+	// First attempt to disambiguate by appending the NodeJS resource type.
+	root := name
+	name = camel(root + typeName)
+	if !nt.assigned[name] {
+		return name
+	}
+
+	// Next, attempt to disambiguate by appending the NodeJS module and type.
+	name = camel(root + moduleName + typeName)
+	if !nt.assigned[name] {
+		return name
+	}
+
+	// Finally, attempt to disambiguate by appending the NodeJS package, module, and type.
+	return nt.disambiguate(camel(root + packageName + moduleName + typeName))
+}
+
+// assignResource assigns an unambiguous name to a resource node.
+func (nt *nameTable) assignResource(n *il.ResourceNode) {
+	name := nt.disambiguateResourceName(n)
+	nt.names[n], nt.assigned[name] = name, true
+}
+
+func assignNames(g *il.Graph, isRootModule bool) map[il.Node]string {
+	nt := &nameTable{
+		names:        make(map[il.Node]string),
+		assigned:     make(map[string]bool),
+		isRootModule: isRootModule,
+	}
+
+	// Assign output names first: given a conflict between nodes, we always want the output node (if any) to win so
+	// that output names are predictable and as consistent with their TF names as is possible.
+	for _, n := range g.Outputs {
+		nt.assignOutput(n)
+	}
+
+	// Next, record all other nodes in the following order:
+	// 1. Locals
+	// 2. Variables
+	// 3. Modules
+	// 4. Resources
+	// Providers should be handled before resources once first-class providers are supported (#11).
+	for _, n := range g.Locals {
+		nt.assignLocal(n)
+	}
+	for _, n := range g.Variables {
+		nt.assignVariable(n)
+	}
+	for _, n := range g.Modules {
+		nt.assignModule(n)
+	}
+
+	// We handle resources in two passes: in the first pass, we decide which names are ambiguous, and in the second pass
+	// we assign names. We do this so that we can apply disambiguation more uniformly across resource names.
+	resourceGroups := make(map[string][]*il.ResourceNode)
+	for _, n := range g.Resources {
+		name, _ := nt.tsName(n.Config.Name)
+		resourceGroups[name] = append(resourceGroups[name], n)
+	}
+	for name, group := range resourceGroups {
+		if len(group) == 1 {
+			// If there is only one resource in this group, allow disambiguation to happen normally.
+			nt.assignResource(group[0])
+		} else {
+			// Otherwise, force all resources in this group to disambiguate.
+			nt.assigned[name] = true
+			for _, n := range group {
+				nt.assignResource(n)
+			}
+		}
+	}
+
+	return nt.names
+}

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -110,12 +110,16 @@ func TestAssignNames(t *testing.T) {
 			"vpc",
 			"name",
 			"ec2",
+			"local",
+			"localInput",
+			"localInput1",
 		}),
 		Variables: variables([]string{
 			"region",
 			"name",
 			"instance",
 			"default_vpc",
+			"local",
 		}),
 		Modules: modules([]string{
 			"module",
@@ -143,11 +147,15 @@ func TestAssignNames(t *testing.T) {
 	assert.Equal(t, "vpc", names[g.Locals["vpc"]])
 	assert.Equal(t, "myName", names[g.Locals["name"]])
 	assert.Equal(t, "ec2", names[g.Locals["ec2"]])
+	assert.Equal(t, "local", names[g.Locals["local"]])
+	assert.Equal(t, "localInput", names[g.Locals["localInput"]])
+	assert.Equal(t, "localInput1", names[g.Locals["localInput1"]])
 
 	assert.Equal(t, "region", names[g.Variables["region"]])
 	assert.Equal(t, "nameInput", names[g.Variables["name"]])
 	assert.Equal(t, "instance", names[g.Variables["instance"]])
 	assert.Equal(t, "defaultVpc", names[g.Variables["default_vpc"]])
+	assert.Equal(t, "localInput2", names[g.Variables["local"]])
 
 	assert.Equal(t, "module", names[g.Modules["module"]])
 	assert.Equal(t, "nameInstance", names[g.Modules["name"]])

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -1,0 +1,150 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/tf2pulumi/il"
+	"github.com/stretchr/testify/assert"
+)
+
+func outputs(names []string) map[string]*il.OutputNode {
+	m := make(map[string]*il.OutputNode)
+	for _, name := range names {
+		m[name] = &il.OutputNode{Config: &config.Output{Name: name}}
+	}
+	return m
+}
+
+func locals(names []string) map[string]*il.LocalNode {
+	m := make(map[string]*il.LocalNode)
+	for _, name := range names {
+		m[name] = &il.LocalNode{Config: &config.Local{Name: name}}
+	}
+	return m
+}
+
+func variables(names []string) map[string]*il.VariableNode {
+	m := make(map[string]*il.VariableNode)
+	for _, name := range names {
+		m[name] = &il.VariableNode{Config: &config.Variable{Name: name}}
+	}
+	return m
+}
+
+func modules(names []string) map[string]*il.ModuleNode {
+	m := make(map[string]*il.ModuleNode)
+	for _, name := range names {
+		m[name] = &il.ModuleNode{Config: &config.Module{Name: name}}
+	}
+	return m
+}
+
+func resources(toks []string) map[string]*il.ResourceNode {
+	m := make(map[string]*il.ResourceNode)
+	for _, tok := range toks {
+		// Split the token into a type and a name
+		components := strings.Split(tok, "::")
+		typ, name := tokens.Type(components[0]), components[1]
+
+		tfType := string(typ.Package()) + "_" +
+			tfbridge.PulumiToTerraformName(string(typ.Module().Name())+string(typ.Name()), nil)
+
+		// Create a provider for this resource
+		provider := &il.ProviderNode{
+			PluginName: string(typ.Package()),
+			Info: &tfbridge.ProviderInfo{
+				Resources: map[string]*tfbridge.ResourceInfo{
+					tfType: &tfbridge.ResourceInfo{Tok: typ},
+				},
+			},
+		}
+
+		m[tok] = &il.ResourceNode{
+			Config: &config.Resource{
+				Name: name,
+				Type: tfType,
+			},
+			Provider: provider,
+		}
+	}
+	return m
+}
+
+func TestAssignNames(t *testing.T) {
+	// Create a graph with a mix of ambiguous and non-ambiguous names.
+	g := &il.Graph{
+		Outputs: outputs([]string{
+			"vpc_id",
+			"security_group_id",
+			"name",
+		}),
+		Locals: locals([]string{
+			"vpc_id",
+			"vpc",
+			"name",
+			"ec2",
+		}),
+		Variables: variables([]string{
+			"region",
+			"name",
+			"instance",
+		}),
+		Modules: modules([]string{
+			"module",
+			"name",
+			"ec2",
+		}),
+		Resources: resources([]string{
+			"aws:ec2:Vpc::default_vpc",
+			"aws:ec2:Vpc::default",
+			"aws:ec2:Instance::default",
+			"aws:ec2:Instance::i",
+			"aws:lightsail:Instance::main",
+			"gcp:compute:Instance::main",
+		}),
+	}
+
+	names := assignNames(g, true)
+
+	assert.Equal(t, "vpcId", names[g.Outputs["vpc_id"]])
+	assert.Equal(t, "securityGroupId", names[g.Outputs["security_group_id"]])
+	assert.Equal(t, "name", names[g.Outputs["name"]])
+
+	assert.Equal(t, "myVpcId", names[g.Locals["vpc_id"]])
+	assert.Equal(t, "vpc", names[g.Locals["vpc"]])
+	assert.Equal(t, "myName", names[g.Locals["name"]])
+	assert.Equal(t, "ec2", names[g.Locals["ec2"]])
+
+	assert.Equal(t, "region", names[g.Variables["region"]])
+	assert.Equal(t, "nameInput", names[g.Variables["name"]])
+	assert.Equal(t, "instance", names[g.Variables["instance"]])
+
+	assert.Equal(t, "module", names[g.Modules["module"]])
+	assert.Equal(t, "nameInstance", names[g.Modules["name"]])
+	assert.Equal(t, "ec2Instance", names[g.Modules["ec2"]])
+
+	assert.Equal(t, "defaultVpc", names[g.Resources["aws:ec2:Vpc::default_vpc"]])
+	assert.Equal(t, "defaultEc2Vpc", names[g.Resources["aws:ec2:Vpc::default"]])
+	assert.Equal(t, "defaultInstance", names[g.Resources["aws:ec2:Instance::default"]])
+	assert.Equal(t, "awsEc2Instance", names[g.Resources["aws:ec2:Instance::i"]])
+	assert.Equal(t, "mainInstance", names[g.Resources["aws:lightsail:Instance::main"]])
+	assert.Equal(t, "mainComputeInstance", names[g.Resources["gcp:compute:Instance::main"]])
+}

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -106,6 +106,7 @@ func TestAssignNames(t *testing.T) {
 			"region",
 			"name",
 			"instance",
+			"default_vpc",
 		}),
 		Modules: modules([]string{
 			"module",
@@ -113,7 +114,7 @@ func TestAssignNames(t *testing.T) {
 			"ec2",
 		}),
 		Resources: resources([]string{
-			"aws:ec2:Vpc::default_vpc",
+			"aws:ec2:Vpc::cluster_vpc",
 			"aws:ec2:Vpc::default",
 			"aws:ec2:Instance::default",
 			"aws:ec2:Instance::i",
@@ -136,12 +137,13 @@ func TestAssignNames(t *testing.T) {
 	assert.Equal(t, "region", names[g.Variables["region"]])
 	assert.Equal(t, "nameInput", names[g.Variables["name"]])
 	assert.Equal(t, "instance", names[g.Variables["instance"]])
+	assert.Equal(t, "defaultVpc", names[g.Variables["default_vpc"]])
 
 	assert.Equal(t, "module", names[g.Modules["module"]])
 	assert.Equal(t, "nameInstance", names[g.Modules["name"]])
 	assert.Equal(t, "ec2Instance", names[g.Modules["ec2"]])
 
-	assert.Equal(t, "defaultVpc", names[g.Resources["aws:ec2:Vpc::default_vpc"]])
+	assert.Equal(t, "clusterVpc", names[g.Resources["aws:ec2:Vpc::cluster_vpc"]])
 	assert.Equal(t, "defaultEc2Vpc", names[g.Resources["aws:ec2:Vpc::default"]])
 	assert.Equal(t, "defaultInstance", names[g.Resources["aws:ec2:Instance::default"]])
 	assert.Equal(t, "awsEc2Instance", names[g.Resources["aws:ec2:Instance::i"]])

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -190,12 +190,12 @@ import * as aws from "@pulumi/aws";
 
 const config = new pulumi.Config();
 // Accept the AWS region as input.
-const var_aws_region = config.get("awsRegion") || "us-west-2";
+const awsRegion = config.get("awsRegion") || "us-west-2";
 
 // Create a security group.
 //
 // This group should allow SSH and HTTP access.
-const aws_security_group_default = new aws.ec2.SecurityGroup("default", {
+const defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
     // outbound internet access
     egress: [{
         cidrBlocks: ["0.0.0.0/0"],
@@ -225,7 +225,7 @@ const aws_security_group_default = new aws.ec2.SecurityGroup("default", {
 // Create a VPC.
 //
 // Note that the VPC has been tagged appropriately.
-const aws_vpc_default = new aws.ec2.Vpc("default", {
+const defaultVpc = new aws.ec2.Vpc("default", {
     cidrBlock: "10.0.0.0/16", // Just one CIDR block
     enableDnsHostnames: true, // Definitely want DNS hostnames.
     // The tag collection for this VPC.
@@ -235,18 +235,18 @@ const aws_vpc_default = new aws.ec2.Vpc("default", {
     },
 });
 // The region, again
-const local_region = var_aws_region; // why not
+const region = awsRegion; // why not
 // The VPC details
-const local_vpc = [{
+const vpc = [{
     // The ID
-    id: aws_vpc_default.id,
+    id: defaultVpc.id,
 }];
 
 // Output the SG name.
 //
 // We pull the name from the default SG.
 // Take the value from the default SG.
-export const securityGroupName = aws_security_group_default.name; // Neat!
+export const securityGroupName = defaultSecurityGroup.name; // Neat!
 `
 
 	dir, err := ioutil.TempDir("", "")

--- a/gen/nodejs/http.go
+++ b/gen/nodejs/http.go
@@ -58,7 +58,7 @@ func (g *generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count str
 func (g *generator) generateHTTP(r *il.ResourceNode) error {
 	contract.Require(r.Provider.Config.Name == "http", "r")
 
-	name := resName(r.Config.Type, r.Config.Name)
+	name := g.nodeName(r)
 
 	if r.Count == nil {
 		inputs, err := g.computeHTTPInputs(r, false, "")

--- a/tests/terraform/aws/lb-listener/index.base.ts
+++ b/tests/terraform/aws/lb-listener/index.base.ts
@@ -1,13 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const aws_cognito_user_pool_pool = new aws.cognito.UserPool("pool", {});
-const aws_cognito_user_pool_client_client = new aws.cognito.UserPoolClient("client", {});
-const aws_cognito_user_pool_domain_domain = new aws.cognito.UserPoolDomain("domain", {});
-const aws_lb_front_end = new aws.elasticloadbalancingv2.LoadBalancer("front_end", {});
-const aws_lb_target_group_front_end = new aws.elasticloadbalancingv2.TargetGroup("front_end", {});
-const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener("front_end", {
-    defaultAction: pulumi.all([aws_cognito_user_pool_pool.arn, aws_cognito_user_pool_client_client.id, aws_cognito_user_pool_domain_domain.domain, aws_lb_target_group_front_end.arn]).apply(([__arg0, __arg1, __arg2, __arg3]) => (() => {
+const pool = new aws.cognito.UserPool("pool", {});
+const client = new aws.cognito.UserPoolClient("client", {});
+const domain = new aws.cognito.UserPoolDomain("domain", {});
+const frontEndLoadBalancer = new aws.elasticloadbalancingv2.LoadBalancer("front_end", {});
+const frontEndTargetGroup = new aws.elasticloadbalancingv2.TargetGroup("front_end", {});
+const frontEndListener = new aws.elasticloadbalancingv2.Listener("front_end", {
+    defaultAction: pulumi.all([pool.arn, client.id, domain.domain, frontEndTargetGroup.arn]).apply(([__arg0, __arg1, __arg2, __arg3]) => (() => {
         throw "tf2pulumi error: aws_lb_listener.front_end.default_action: expected at most one item in list, got 2";
         return [
             {
@@ -24,7 +24,7 @@ const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener("front
             },
         ];
     })()),
-    loadBalancerArn: aws_lb_front_end.arn,
+    loadBalancerArn: frontEndLoadBalancer.arn,
     port: 80,
     protocol: "HTTP",
 });


### PR DESCRIPTION
Rather than generating simple, ugly, and ~probably unique names for
top-level nodes, assign the "nicest" names possible that are guaranteed
to be legal and unambiguous. The algorithm works like so:

- Assign names to outputs, locals, variables, and modules in that order.
    - Outputs are never ambiguous, as they are assigned first and are
      guaranteed to be unique in HCL
    - If a local is ambiguous, attempt to disambiguate by prepending "my"
    - If a variable is ambiguous, attempt to disambiguate by appending
      "Input"
    - If a module is ambiguous, attempt to disambiguate by appending
      "Instance"
    - If the name remains ambiguous, append an increasing integer
      starting at 1 until it is no longer ambiguous.
- Assign resource names.
    - If the resource's name is a single character, pretend it has no
      name and requires disambiguation.
    - If the resource name is ambiguous, try appending the following to
      the resource name (in order):

      1. The resource type
      2. The resource module and type
      3. The resource package, module, and type

      If the name remains ambiguous after step (3), append an increasing
      integer starting at 1 until it is no longer ambiguous.

As an example of the improvements this delivers, see the lb-listener
test's resource names go from this:

```
const aws_cognito_user_pool_pool = new aws.cognito.UserPool(...)
const aws_cognito_user_pool_client_client = new aws.cognito.UserPoolClient(...)
const aws_cognito_user_pool_domain_domain = new aws.cognito.UserPoolDomain(...)
const aws_lb_front_end = new aws.elasticloadbalancingv2.LoadBalancer(...)
const aws_lb_target_group_front_end = new aws.elasticloadbalancingv2.TargetGroup(...)
const aws_lb_listener_front_end = new aws.elasticloadbalancingv2.Listener(...)
```

to this:

```
const pool = new aws.cognito.UserPool(...)
const client = new aws.cognito.UserPoolClient(...)
const domain = new aws.cognito.UserPoolDomain(...)
const frontEndLoadBalancer = new aws.elasticloadbalancingv2.LoadBalancer(...)
const frontEndTargetGroup = new aws.elasticloadbalancingv2.TargetGroup(...)
const frontEndListener = new aws.elasticloadbalancingv2.Listener(...)
```

Fixes #31.