### PR TITLE
Add support for filtering resource names

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/terraform/command"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/svchost"
 	"github.com/hashicorp/terraform/svchost/auth"
@@ -66,9 +67,11 @@ func Convert(opts Options) error {
 		}
 		for _, g := range gs {
 			for _, r := range g.Resources {
-				il.FilterProperties(r, func(key string, _ il.BoundNode) bool {
-					return key != opts.ResourceNameProperty
-				})
+				if r.Config.Mode == config.ManagedResourceMode {
+					il.FilterProperties(r, func(key string, _ il.BoundNode) bool {
+						return key != opts.ResourceNameProperty
+					})
+				}
 			}
 		}
 	}

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -135,11 +135,10 @@ func (g *generator) genApplyArg(w io.Writer, index int) {
 			g.gen(w, ".map(v => v")
 		}
 
-		r := v.ILNode.(*il.ResourceNode)
 		sch, elements := v.Schemas, v.Elements
-		if r.Config.Mode == config.ManagedResourceMode {
+		if g.resourceMode(v) == config.ManagedResourceMode {
 			sch, elements = sch.PropertySchemas(elements[0]), elements[1:]
-		} else if r.Provider.Config.Name == "http" {
+		} else if r, ok := v.ILNode.(*il.ResourceNode); ok && r.Provider.Config.Name == "http" {
 			elements = nil
 		}
 		for _, e := range elements {

--- a/il/rewriters.go
+++ b/il/rewriters.go
@@ -238,3 +238,13 @@ func RewriteAssets(n BoundNode) (BoundNode, error) {
 
 	return VisitBoundNode(n, IdentityVisitor, rewriter)
 }
+
+// FilterProperties removes any properties at the root of the given resource for which the given filter fucntion
+// returns false.
+func FilterProperties(r *ResourceNode, filter func(key string, property BoundNode) bool) {
+	for key, prop := range r.Properties.Elements {
+		if !filter(key, prop) {
+			delete(r.Properties.Elements, key)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 
 func main() {
 	var opts convert.Options
+	resourceNameProperty := ""
 
 	rootCmd := &cobra.Command{
 		Use:   "tf2pulumi",
@@ -37,6 +38,9 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		SilenceUsage:  true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if resourceNameProperty != "" {
+				opts.FilterResourceNames, opts.ResourceNameProperty = true, resourceNameProperty
+			}
 			return convert.Convert(opts)
 		},
 	}
@@ -48,6 +52,8 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"allows code generation to continue if the config references missing variables")
 	flag.BoolVar(&opts.AllowMissingComments, "allow-missing-comments", true,
 		"allows code generation to continue if there are errors extracting comments")
+	flag.StringVar(&resourceNameProperty, "filter-resource-names", "",
+		"when set, the property with the given key will be removed from all resources")
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",

--- a/tests/terraform/aws/asg/main.tf
+++ b/tests/terraform/aws/asg/main.tf
@@ -1,15 +1,10 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
 }
 
 resource "aws_elb" "web-elb" {
-  # name = "terraform-example-elb"
+  name = "terraform-example-elb"
 
   # The same availability zone as our instances
   availability_zones = ["${split(",", var.availability_zones)}"]
@@ -32,7 +27,7 @@ resource "aws_elb" "web-elb" {
 
 resource "aws_autoscaling_group" "web-asg" {
   availability_zones   = ["${split(",", var.availability_zones)}"]
-  # name                 = "terraform-example-asg"
+  name                 = "terraform-example-asg"
   max_size             = "${var.asg_max}"
   min_size             = "${var.asg_min}"
   desired_capacity     = "${var.asg_desired}"
@@ -49,7 +44,7 @@ resource "aws_autoscaling_group" "web-asg" {
 }
 
 resource "aws_launch_configuration" "web-lc" {
-  # name          = "terraform-example-lc"
+  name          = "terraform-example-lc"
   image_id      = "${lookup(var.aws_amis, var.aws_region)}"
   instance_type = "${var.instance_type}"
 
@@ -61,7 +56,7 @@ resource "aws_launch_configuration" "web-lc" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  # name        = "terraform_example_sg"
+  name        = "terraform_example_sg"
   description = "Used in the terraform"
 
   # SSH access from anywhere

--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -38,44 +38,44 @@ func integrationTest(t *testing.T, program *integration.ProgramTestOptions, comp
 }
 
 func TestASG(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, "name", true)
 }
 
 func TestCognitoUserPool(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, "name", true)
 }
 
 func TestCount(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, "name", true)
 }
 
 func TestECSALB(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: call to cidrsubnet")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, "name", true)
 }
 
 func TestEIP(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, "name", true)
 }
 
 func TestELB(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, "name", true)
 }
 
 func TestELB2(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, "name", true)
 }
 
 func TestLBListener(t *testing.T) {
 	// Note we don't compile this one, since it contains semantic errors.
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, false)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, "name", false)
 }
 
 func TestLambda(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, "name", true)
 }
 
 func TestNetworking(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: provider instances")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, "name", true)
 }

--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -34,48 +34,48 @@ func integrationTest(t *testing.T, program *integration.ProgramTestOptions, comp
 	program.Config["aws:region"] = region
 	program.ExpectRefreshChanges = true
 
-	terraform.IntegrationTest(t, program, compile)
+	terraform.IntegrationTest(t, program, "name", compile)
 }
 
 func TestASG(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, true)
 }
 
 func TestCognitoUserPool(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, true)
 }
 
 func TestCount(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, true)
 }
 
 func TestECSALB(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: call to cidrsubnet")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, true)
 }
 
 func TestEIP(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, true)
 }
 
 func TestELB(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, true)
 }
 
 func TestELB2(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, true)
 }
 
 func TestLBListener(t *testing.T) {
 	// Note we don't compile this one, since it contains semantic errors.
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, "name", false)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, false)
 }
 
 func TestLambda(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, true)
 }
 
 func TestNetworking(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: provider instances")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, "name", true)
+	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, true)
 }

--- a/tests/terraform/aws/cognito-user-pool/main.tf
+++ b/tests/terraform/aws/cognito-user-pool/main.tf
@@ -1,10 +1,5 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 resource "aws_iam_role" "main" {
-  # name = "terraform-example-lambda"
+  name = "terraform-example-lambda"
 
   assume_role_policy = <<EOF
 {
@@ -32,7 +27,7 @@ resource "aws_lambda_function" "main" {
 }
 
 resource "aws_iam_role" "cidp" {
-  # name = "terraform-example-cognito-idp"
+  name = "terraform-example-cognito-idp"
   path = "/service-role/"
 
   assume_role_policy = <<POLICY
@@ -58,7 +53,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "main" {
-  # name = "terraform-example-cognito-idp"
+  name = "terraform-example-cognito-idp"
   role = "${aws_iam_role.cidp.id}"
 
   policy = <<EOF
@@ -80,7 +75,7 @@ EOF
 }
 
 resource "aws_cognito_user_pool" "pool" {
-  # name                       = "terraform-example"
+  name                       = "terraform-example"
   email_verification_subject = "Device Verification Code"
   email_verification_message = "Please use the following code {####}"
   sms_verification_message   = "{####} Baz"

--- a/tests/terraform/aws/count/main.tf
+++ b/tests/terraform/aws/count/main.tf
@@ -1,15 +1,10 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
 }
 
 resource "aws_elb" "web" {
-  # name = "terraform-example-elb"
+  name = "terraform-example-elb"
 
   # The same availability zone as our instances
   availability_zones = ["${aws_instance.web.*.availability_zone}"]

--- a/tests/terraform/aws/ecs-alb/main.tf
+++ b/tests/terraform/aws/ecs-alb/main.tf
@@ -1,8 +1,3 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -47,7 +42,7 @@ resource "aws_route_table_association" "a" {
 ### Compute
 
 resource "aws_autoscaling_group" "app" {
-  # name                 = "tf-test-asg"
+  name                 = "tf-test-asg"
   vpc_zone_identifier  = ["${aws_subnet.main.*.id}"]
   min_size             = "${var.asg_min}"
   max_size             = "${var.asg_max}"

--- a/tests/terraform/aws/eip/main.tf
+++ b/tests/terraform/aws/eip/main.tf
@@ -1,8 +1,3 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -16,7 +11,7 @@ resource "aws_eip" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  # name        = "eip_example"
+  name        = "eip_example"
   description = "Used in the terraform"
 
   # SSH access from anywhere

--- a/tests/terraform/aws/elb/main.tf
+++ b/tests/terraform/aws/elb/main.tf
@@ -1,8 +1,3 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -56,7 +51,7 @@ resource "aws_route_table_association" "a" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  # name        = "instance_sg"
+  name        = "instance_sg"
   description = "Used in the terraform"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -88,7 +83,7 @@ resource "aws_security_group" "default" {
 # Our elb security group to access
 # the ELB over HTTP
 resource "aws_security_group" "elb" {
-  # name        = "elb_sg"
+  name        = "elb_sg"
   description = "Used in the terraform"
 
   vpc_id = "${aws_vpc.default.id}"
@@ -114,7 +109,7 @@ resource "aws_security_group" "elb" {
 }
 
 resource "aws_elb" "web" {
-  # name = "example-elb"
+  name = "example-elb"
 
   # The same availability zone as our instance
   subnets = ["${aws_subnet.tf_test_subnet.id}"]
@@ -146,7 +141,7 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "default" {
-  # name                     = "lbpolicy"
+  name                     = "lbpolicy"
   load_balancer            = "${aws_elb.web.id}"
   lb_port                  = 80
   cookie_expiration_period = 600

--- a/tests/terraform/aws/lambda/main.tf
+++ b/tests/terraform/aws/lambda/main.tf
@@ -1,8 +1,3 @@
-# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
-# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
-# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
-# for us.
-
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
@@ -31,7 +26,7 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  # name               = "iam_for_lambda"
+  name               = "iam_for_lambda"
   assume_role_policy = "${data.aws_iam_policy_document.policy.json}"
 }
 

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -34,7 +34,7 @@ const (
 	baselineFile = "index.base.ts"
 )
 
-func generateCode(t *testing.T, program *integration.ProgramTestOptions) {
+func generateCode(t *testing.T, program *integration.ProgramTestOptions, filterName string) {
 	stdout := program.Stdout
 	if stdout == nil {
 		stdout = os.Stdout
@@ -57,8 +57,13 @@ func generateCode(t *testing.T, program *integration.ProgramTestOptions) {
 	}
 	defer contract.IgnoreClose(indexTS)
 
+	var args []string
+	if filterName != "" {
+		args = append(args, "--filter-resource-names="+filterName)
+	}
+
 	var stderr bytes.Buffer
-	cmd = exec.Command("tf2pulumi")
+	cmd = exec.Command("tf2pulumi", args...)
 	cmd.Dir = program.Dir
 	cmd.Stdout, cmd.Stderr = indexTS, &stderr
 	if err = cmd.Run(); err != nil {
@@ -66,7 +71,7 @@ func generateCode(t *testing.T, program *integration.ProgramTestOptions) {
 	}
 }
 
-func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, compile bool) {
+func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, filterName string, compile bool) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("expected a valid working directory: %v", err)

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -91,7 +91,7 @@ func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, filt
 	program.Dir = targetDir
 
 	// Generate the Pulumi TypeScript program.
-	generateCode(t, program)
+	generateCode(t, program, filterName)
 
 	// If there is a baseline file, ensure that it matches.
 	baselinePath := filepath.Join(targetDir, baselineFile)


### PR DESCRIPTION
Our providers commonly support auto-naming resources if a name is not
specified in order to help avoid name collisions. These changes add a
flag to `tf2pulumi` that can be used to specify the key of a name
property to filter from all resources in order to allow the autonamer to
go to work.

Fixes #43.