### PR TITLE
Fix two binding issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.4.8 (Unreleased)
 
+- Allow references to `terraform.workspace` (tf2pulumi#68)
+- Allow normal references to counted resources. Terraform allows this when a resource's count evaluates to 1, so 
+  we code generate this as a reference to the first resource in the counted resource's list.
+
 ## v0.4.7 (Released February 8, 2019)
 
 ### Improvements

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -212,6 +212,8 @@ func (g *generator) genCall(w io.Writer, n *il.BoundCall) {
 		g.genf(w, "new pulumi.asset.FileAsset(%v)", n.Args[0])
 	case "__coerce":
 		g.genCoercion(w, n.Args[0], n.Type())
+	case "__getStack":
+		g.genf(w, "pulumi.getStack()")
 	case "base64decode":
 		g.genf(w, "Buffer.from(%v, \"base64\").toString()", n.Args[0])
 	case "base64encode":


### PR DESCRIPTION
- Support `terraform.workspace` references. The moral equivalent of the
  Terraform workspace name is the Pulumi stack name, so these turn into
  `pulumi.getStack()`.
- Allow non-splat/indexed access to counted resources. This is allowed
  in Terraform when the count evaluates to 1.

Fixes #68.