### PR TITLE
Fix data sources with output-typed inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Allow references to `terraform.workspace` (tf2pulumi#68)
 - Allow normal references to counted resources. Terraform allows this when a resource's count evaluates to 1, so 
   we code generate this as a reference to the first resource in the counted resource's list.
+- Data sources with inputs that are outputs of other resources and data sources are now generated correctly.
 
 ## v0.4.7 (Released February 8, 2019)
 

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -212,6 +212,15 @@ func (g *generator) genCall(w io.Writer, n *il.BoundCall) {
 		g.genf(w, "new pulumi.asset.FileAsset(%v)", n.Args[0])
 	case "__coerce":
 		g.genCoercion(w, n.Args[0], n.Type())
+	case "__dataSource":
+		g.gen(w, n.Args[0].(*il.BoundLiteral).Value, "(")
+		for i, v := range n.Args[1:] {
+			if i > 0 {
+				g.gen(w, ", ")
+			}
+			g.gen(w, v)
+		}
+		g.gen(w, ")")
 	case "__getStack":
 		g.genf(w, "pulumi.getStack()")
 	case "base64decode":

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -213,14 +213,7 @@ func (g *generator) genCall(w io.Writer, n *il.BoundCall) {
 	case "__coerce":
 		g.genCoercion(w, n.Args[0], n.Type())
 	case "__dataSource":
-		g.gen(w, n.Args[0].(*il.BoundLiteral).Value, "(")
-		for i, v := range n.Args[1:] {
-			if i > 0 {
-				g.gen(w, ", ")
-			}
-			g.gen(w, v)
-		}
-		g.gen(w, ")")
+		g.genf(w, "%s(%s)", n.Args[0].(*il.BoundLiteral).Value, n.Args[1])
 	case "__getStack":
 		g.genf(w, "pulumi.getStack()")
 	case "base64decode":

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -567,6 +567,43 @@ func (n *BoundError) dump(d *dumper) {
 func (n *BoundError) isNode() {}
 func (n *BoundError) isExpr() {}
 
+// BoundPropertyExpr wraps a BoundMapProperty or BoundListProperty in a BoundExpr. This is intended primarily for the
+// use of transforms that must pass bound properties to intrinsics.
+type BoundPropertyExpr struct {
+	// The type of the node.
+	NodeType Type
+	// Comments is the set of comments associated with this node, if any.
+	NodeComments *Comments
+	// The wrapped property.
+	Value BoundNode
+}
+
+// Type returns the type of the expression.
+func (n *BoundPropertyExpr) Type() Type {
+	return n.NodeType
+}
+
+// Comments returns the comments attached to this node, if any.
+func (n *BoundPropertyExpr) Comments() *Comments {
+	return n.NodeComments
+}
+
+// setComments attaches the given comments to this node.
+func (n *BoundPropertyExpr) setComments(c *Comments) {
+	n.NodeComments = c
+}
+
+func (n *BoundPropertyExpr) isNode() {}
+func (n *BoundPropertyExpr) isExpr() {}
+
+func (n *BoundPropertyExpr) dump(d *dumper) {
+	d.dump("(propertyExpr ", fmt.Sprintf("%v", n.Type()))
+	d.indented(func() {
+		d.dump("\n", d.indent, n.Value)
+	})
+	d.dump("\n", d.indent, ")")
+}
+
 // DumpBoundNode dumps the string representation of the given bound node to the given writer.
 func DumpBoundNode(w io.Writer, e BoundNode) {
 	e.dump(&dumper{w: w})

--- a/il/boundTree_visitor.go
+++ b/il/boundTree_visitor.go
@@ -129,6 +129,15 @@ func visitBoundOutput(n *BoundOutput, pre, post BoundNodeVisitor) (BoundNode, er
 	return post(n)
 }
 
+func visitBoundPropertyExpr(n *BoundPropertyExpr, pre, post BoundNodeVisitor) (BoundNode, error) {
+	value, err := VisitBoundNode(n.Value, pre, post)
+	if err != nil {
+		return nil, err
+	}
+	n.Value = value
+	return post(n)
+}
+
 func visitBoundExprs(ns []BoundExpr, pre, post BoundNodeVisitor) ([]BoundExpr, error) {
 	nils := 0
 	for i, e := range ns {
@@ -216,6 +225,8 @@ func VisitBoundNode(n BoundNode, pre, post BoundNodeVisitor) (BoundNode, error) 
 		return visitBoundMapProperty(n, pre, post)
 	case *BoundOutput:
 		return visitBoundOutput(n, pre, post)
+	case *BoundPropertyExpr:
+		return visitBoundPropertyExpr(n, pre, post)
 	case *BoundVariableAccess:
 		return post(n)
 	default:


### PR DESCRIPTION
Data sources with output-typed inputs need to be generated as a call to
`apply` that contains a call to the data source itself with the resolved
outputs. These changes implement this in a moderately subtle fashion:
instead of generating the data source ad-hoc, it is turned into an
intrinsic that is then handed over to the apply rewriter. If the apply
rewriter does not transform the intrinsic, the call to the data source
is wrapped in a call to `pulumi.output` in order to keep the generated
code in normal form.

Fixes #67.