### PR TITLE
Add skeleton for Python backend

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -87,7 +87,7 @@ func Convert(opts Options) error {
 		}
 	}
 
-	generator, err := createGenerator("auto", opts)
+	generator, err := newGenerator("auto", opts)
 	if err != nil {
 		return errors.Wrapf(err, "creating generator")
 	}
@@ -158,7 +158,7 @@ func buildGraphs(tree *module.Tree, isRoot bool, opts Options) ([]*il.Graph, err
 	return append(children, g), nil
 }
 
-func createGenerator(projectName string, opts Options) (gen.Generator, error) {
+func newGenerator(projectName string, opts Options) (gen.Generator, error) {
 	switch opts.TargetLanguage {
 	case LanguageTypescript:
 		return nodejs.New(projectName, opts.Writer), nil

--- a/gen/python/generator.go
+++ b/gen/python/generator.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package python implements a Python back-end for tf2pulumi's intermediate representation. It is responsible for
+// translating the Graph IR emit by the frontend into valid Pulumi Python code that is as semantically equivalent to
+// the original Terraform as possible.
+package python
+
+import (
+	"errors"
+	"io"
+
+	"github.com/pulumi/tf2pulumi/gen"
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+// New creates a new Python Generator that writes to the given writer and uses the given project name.
+func New(projectName string, w io.Writer) gen.Generator {
+	return &generator{
+		projectName: projectName,
+		w:           w,
+	}
+}
+
+type generator struct {
+	projectName string
+	w           io.Writer
+}
+
+func (g *generator) GeneratePreamble(gs []*il.Graph) error {
+	return nil
+}
+
+func (g *generator) BeginModule(mod *il.Graph) error {
+	if len(mod.Tree.Path()) != 0 {
+		return errors.New("NYI: Python Modules")
+	}
+	return nil
+}
+
+func (g *generator) EndModule(mod *il.Graph) error {
+	return nil
+}
+
+func (g *generator) GenerateVariables(vs []*il.VariableNode) error {
+	if len(vs) != 0 {
+		return errors.New("NYI: Python Variables")
+	}
+	return nil
+}
+
+func (g *generator) GenerateModule(m *il.ModuleNode) error {
+	return errors.New("NYI: Python Modules")
+}
+
+func (g *generator) GenerateLocal(l *il.LocalNode) error {
+	return errors.New("NYI: Python Locals")
+}
+
+func (g *generator) GenerateResource(r *il.ResourceNode) error {
+	return errors.New("NYI: Python Resources")
+}
+
+func (g *generator) GenerateOutputs(os []*il.OutputNode) error {
+	if len(os) != 0 {
+		return errors.New("NYI: Python Outputs")
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -54,7 +54,8 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"allows code generation to continue if there are errors extracting comments")
 	flag.StringVar(&resourceNameProperty, "filter-resource-names", "",
 		"when set, the property with the given key will be removed from all resources")
-
+	flag.StringVar(&opts.TargetLanguage, "target-language", "typescript",
+		"sets the target language")
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of tf2pulumi",


### PR DESCRIPTION
This commit adds a skeleton backend for Python that does nothing. It
hooks up the relevant plumbing bits in the frontend to select Python as
a target language and generate a Python generator if requested. The
backend basically does nothing and emits NYIs for everything.

Future commits will incrementally build up the Python backend.