### PR TITLE
 Augment integration test harness

### DIFF
--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -15,67 +15,79 @@
 package main
 
 import (
-	"os"
 	"testing"
-
-	"github.com/pulumi/pulumi/pkg/testing/integration"
 
 	"github.com/pulumi/tf2pulumi/tests/terraform"
 )
 
-func integrationTest(t *testing.T, program *integration.ProgramTestOptions, compile bool) {
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		t.Skipf("Skipping test due to missing AWS_REGION environment variable")
-	}
-	if program.Config == nil {
-		program.Config = make(map[string]string)
-	}
-	program.Config["aws:region"] = region
-	program.ExpectRefreshChanges = true
-
-	terraform.IntegrationTest(t, program, "name", compile)
-}
-
 func TestASG(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "asg"}, true)
+	terraform.RunTest(t, "asg",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestCognitoUserPool(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "cognito-user-pool"}, true)
+	terraform.RunTest(t, "cognito-user-pool",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestCount(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "count"}, true)
+	terraform.RunTest(t, "count",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestECSALB(t *testing.T) {
-	t.Skipf("Skipping test due to NYI: call to cidrsubnet")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "ecs-alb"}, true)
+	terraform.RunTest(t, "ecs-alb",
+		terraform.Skip("Skipping test due to NYI: call to cidersubnet"),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestEIP(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "eip"}, true)
+	terraform.RunTest(t, "eip",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestELB(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb"}, true)
+	terraform.RunTest(t, "elb",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestELB2(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "elb2"}, true)
+	terraform.RunTest(t, "elb2",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestLBListener(t *testing.T) {
-	// Note we don't compile this one, since it contains semantic errors.
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lb-listener"}, false)
+	terraform.RunTest(t, "lb-listener",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+		// Note we don't compile this one, since it contains semantic errors.
+		terraform.Compile(false),
+	)
 }
 
 func TestLambda(t *testing.T) {
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "lambda"}, true)
+	terraform.RunTest(t, "lambda",
+		terraform.SkipPython(),
+		terraform.RequireAWSRegion(),
+	)
 }
 
 func TestNetworking(t *testing.T) {
-	t.Skipf("Skipping test due to NYI: provider instances")
-	integrationTest(t, &integration.ProgramTestOptions{Dir: "networking"}, true)
+	terraform.RunTest(t, "networking",
+		terraform.Skip("Skipping test due to NYI: provider instances"),
+		terraform.RequireAWSRegion(),
+	)
 }

--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -37,76 +37,52 @@ func RequireAWSRegion() terraform.TestOptionsFunc {
 	}
 }
 
+func RunAWSTest(t *testing.T, dir string, opts ...terraform.TestOptionsFunc) {
+	opts = append(opts, RequireAWSRegion(), terraform.SkipPython())
+	terraform.RunTest(t, dir, opts...)
+}
+
 func TestASG(t *testing.T) {
-	terraform.RunTest(t, "asg",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "asg")
 }
 
 func TestCognitoUserPool(t *testing.T) {
-	terraform.RunTest(t, "cognito-user-pool",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "cognito-user-pool")
 }
 
 func TestCount(t *testing.T) {
-	terraform.RunTest(t, "count",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "count")
 }
 
 func TestECSALB(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: call to cidersubnet")
-	terraform.RunTest(t, "ecs-alb",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "ecs-alb")
 }
 
 func TestEIP(t *testing.T) {
-	terraform.RunTest(t, "eip",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "eip")
 }
 
 func TestELB(t *testing.T) {
-	terraform.RunTest(t, "elb",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "elb")
 }
 
 func TestELB2(t *testing.T) {
-	terraform.RunTest(t, "elb2",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "elb2")
 }
 
 func TestLBListener(t *testing.T) {
-	terraform.RunTest(t, "lb-listener",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
+	RunAWSTest(t, "lb-listener",
 		// Note we don't compile this one, since it contains semantic errors.
 		terraform.Compile(false),
 	)
 }
 
 func TestLambda(t *testing.T) {
-	terraform.RunTest(t, "lambda",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "lambda")
 }
 
 func TestNetworking(t *testing.T) {
 	t.Skipf("Skipping test due to NYI: provider instances")
-	terraform.RunTest(t, "networking",
-		terraform.SkipPython(),
-		RequireAWSRegion(),
-	)
+	RunAWSTest(t, "networking")
 }

--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -15,64 +15,82 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/pulumi/tf2pulumi/tests/terraform"
 )
 
+// RequireAWSRegion reads an AWS region from the `AWS_REGION` environment variable and sets the value of the
+// `aws:region` Pulumi config key to the contents of the environment variable. If the environment variable is not set,
+// the test is skipped.
+func RequireAWSRegion() terraform.TestOptionsFunc {
+	return func(t *testing.T, test *terraform.Test) {
+		region := os.Getenv("AWS_REGION")
+		if region == "" {
+			t.Skipf("Skipping test due to missing AWS_REGION environment variable")
+		}
+		if test.RunOptions.Config == nil {
+			test.RunOptions.Config = make(map[string]string)
+		}
+		test.RunOptions.Config["aws:region"] = region
+	}
+}
+
 func TestASG(t *testing.T) {
 	terraform.RunTest(t, "asg",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestCognitoUserPool(t *testing.T) {
 	terraform.RunTest(t, "cognito-user-pool",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestCount(t *testing.T) {
 	terraform.RunTest(t, "count",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestECSALB(t *testing.T) {
+	t.Skipf("Skipping test due to NYI: call to cidersubnet")
 	terraform.RunTest(t, "ecs-alb",
-		terraform.Skip("Skipping test due to NYI: call to cidersubnet"),
-		terraform.RequireAWSRegion(),
+		terraform.SkipPython(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestEIP(t *testing.T) {
 	terraform.RunTest(t, "eip",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestELB(t *testing.T) {
 	terraform.RunTest(t, "elb",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestELB2(t *testing.T) {
 	terraform.RunTest(t, "elb2",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestLBListener(t *testing.T) {
 	terraform.RunTest(t, "lb-listener",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 		// Note we don't compile this one, since it contains semantic errors.
 		terraform.Compile(false),
 	)
@@ -81,13 +99,14 @@ func TestLBListener(t *testing.T) {
 func TestLambda(t *testing.T) {
 	terraform.RunTest(t, "lambda",
 		terraform.SkipPython(),
-		terraform.RequireAWSRegion(),
+		RequireAWSRegion(),
 	)
 }
 
 func TestNetworking(t *testing.T) {
+	t.Skipf("Skipping test due to NYI: provider instances")
 	terraform.RunTest(t, "networking",
-		terraform.Skip("Skipping test due to NYI: provider instances"),
-		terraform.RequireAWSRegion(),
+		terraform.SkipPython(),
+		RequireAWSRegion(),
 	)
 }

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package terraform provides a test harness for tf2pulumi. It is a thin wrapper on top of the Pulumi CLI's integration
+// test framework while supplying a "compile step" for Terraform code that we'll then convert to Pulumi code.
 package terraform
 
 import (
@@ -23,55 +25,96 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
-	"github.com/stretchr/testify/assert"
 )
 
-const (
-	programFile  = "index.ts"
-	baselineFile = "index.base.ts"
-)
-
-func generateCode(t *testing.T, program *integration.ProgramTestOptions, filterName string) {
-	stdout := program.Stdout
-	if stdout == nil {
-		stdout = os.Stdout
-	}
-	fmt.Fprintf(stdout, "running `terraform init`...\n")
-
-	// Run "terraform init".
-	cmd := exec.Command("terraform", "init")
-	cmd.Dir = program.Dir
-	if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
-		t.Fatalf("'terraform init' failed (%v): %v", cmdErr, string(out))
-	}
-
-	fmt.Fprintf(stdout, "running `tf2pulumi`...\n")
-
-	// Generate an index.ts file using `tf2pulumi`.
-	indexTS, err := os.Create(filepath.Join(program.Dir, programFile))
-	if err != nil {
-		t.Fatalf("failed to create index.ts: %v", err)
-	}
-	defer contract.IgnoreClose(indexTS)
-
-	var args []string
-	if filterName != "" {
-		args = append(args, "--filter-resource-names="+filterName)
-	}
-
-	var stderr bytes.Buffer
-	cmd = exec.Command("tf2pulumi", args...)
-	cmd.Dir = program.Dir
-	cmd.Stdout, cmd.Stderr = indexTS, &stderr
-	if err = cmd.Run(); err != nil {
-		t.Fatalf("failed to generate Pulumi program (%v):\n%v", err, stderr.String())
-	}
+// Test represents a single test case. It consists of Terraform input and optionally a "baseline" file that will be
+// diffed against the output of tf2pulumi. Each test case is run on every target unless the target specifically opts
+// out.
+type Test struct {
+	Options    ConvertOptions                  // Base options for tf2pulumi, inherited by all targets.
+	RunOptions *integration.ProgramTestOptions // Options for running the generated Pulumi code
+	Python     *ConvertOptions                 // Python-specific options overriding the base options
+	TypeScript *ConvertOptions                 // TypeScript-specific options overriding the base options
 }
 
-func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, filterName string, compile bool) {
+// ConvertOptions are options controlling the behavior of tf2pulumi. Its arguments are generally converted to
+// command-line flags.
+type ConvertOptions struct {
+	Compile    bool   // If true, run pulumi on the generated code.
+	FilterName string // If non-empty, filter out properties with the given name.
+	Skip       string // If non-empty, skip the current test with the given message.
+}
+
+// With constructs a new ConvertOptions out of a base set of options and a set of options that will override fields that
+// are not set in the base.
+func (c ConvertOptions) With(other ConvertOptions) ConvertOptions {
+	if other.FilterName != "" {
+		c.FilterName = other.FilterName
+	}
+	if other.Skip != "" {
+		c.Skip = other.Skip
+	}
+	return c
+}
+
+// Run executes this test, spawning subtests for each supported target.
+func (test Test) Run(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	t.Run("Python", func(t *testing.T) {
+		runOpts := integration.ProgramTestOptions{}
+		if test.RunOptions != nil {
+			runOpts = *test.RunOptions
+		}
+		convertOpts := test.Options
+		if test.Python != nil {
+			convertOpts = convertOpts.With(*test.Python)
+		}
+
+		targetTest := targetTest{
+			runOpts:     &runOpts,
+			convertOpts: &convertOpts,
+			language:    "python",
+		}
+		targetTest.Run(t)
+	})
+	t.Run("TypeScript", func(t *testing.T) {
+		runOpts := integration.ProgramTestOptions{}
+		if test.RunOptions != nil {
+			runOpts = *test.RunOptions
+		}
+		convertOpts := test.Options
+		if test.TypeScript != nil {
+			convertOpts = convertOpts.With(*test.TypeScript)
+		}
+
+		targetTest := targetTest{
+			runOpts:     &runOpts,
+			convertOpts: &convertOpts,
+			language:    "typescript",
+		}
+		targetTest.Run(t)
+	})
+}
+
+// targetTest is a test case running on a single target.
+type targetTest struct {
+	runOpts     *integration.ProgramTestOptions
+	convertOpts *ConvertOptions
+	language    string
+}
+
+// Run runs the test case on the given target. It is responsible for driving tf2pulumi and the CLI integration test
+// framework to compile and run a program.
+func (test *targetTest) Run(t *testing.T) {
+	if test.convertOpts.Skip != "" {
+		t.Skip(test.convertOpts.Skip)
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("expected a valid working directory: %v", err)
@@ -85,23 +128,23 @@ func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, filt
 	defer func() {
 		contract.IgnoreError(os.RemoveAll(targetDir))
 	}()
-	if err = fsutil.CopyFile(targetDir, filepath.Join(cwd, program.Dir), nil); err != nil {
+	if err = fsutil.CopyFile(targetDir, filepath.Join(cwd, test.runOpts.Dir), nil); err != nil {
 		t.Fatalf("failed to create intermediate directory: %v", err)
 	}
-	program.Dir = targetDir
+	test.runOpts.Dir = targetDir
 
 	// Generate the Pulumi TypeScript program.
-	generateCode(t, program, filterName)
+	test.generateCode(t)
 
 	// If there is a baseline file, ensure that it matches.
-	baselinePath := filepath.Join(targetDir, baselineFile)
+	baselinePath := filepath.Join(targetDir, test.targetBaselineFile())
 	baseline, err := ioutil.ReadFile(baselinePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			t.Fatalf("failed to read baseline file %v: %v", baselinePath, err)
 		}
 	} else {
-		programPath := filepath.Join(targetDir, programFile)
+		programPath := filepath.Join(targetDir, test.targetFile())
 		program, err := ioutil.ReadFile(programPath)
 		if err != nil {
 			t.Fatalf("failed to read program file %v: %v", programPath, err)
@@ -111,7 +154,147 @@ func IntegrationTest(t *testing.T, program *integration.ProgramTestOptions, filt
 	}
 
 	// Now, if desired, finally ensure that it actually compiles (and anything else the specific test requires).
-	if compile {
-		integration.ProgramTest(t, program)
+	if test.convertOpts.Compile {
+		integration.ProgramTest(t, test.runOpts)
 	}
+}
+
+// targetFile returns the filename that tf2pulumi should write its output to.
+func (test *targetTest) targetFile() string {
+	switch test.language {
+	case "python":
+		return "__main__.py"
+	case "typescript":
+		return "index.ts"
+	default:
+		panic("unknown language")
+	}
+}
+
+// targetBaselineFile returns the filename that, if the file exists, contains a baseline output that the test harness
+// should diff against tf2pulumi's actual output.
+func (test *targetTest) targetBaselineFile() string {
+	switch test.language {
+	case "python":
+		return "__main__.base.py"
+	case "typescript":
+		return "index.base.ts"
+	default:
+		panic("unknown language")
+	}
+}
+
+// generateCode drives terraform and tf2pulumi to convert the terraform code in the target directory to pulumi code.
+func (test *targetTest) generateCode(t *testing.T) {
+	stdout := test.runOpts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	fmt.Fprintf(stdout, "running `terraform init`...\n")
+
+	// Run "terraform init".
+	cmd := exec.Command("terraform", "init")
+	cmd.Dir = test.runOpts.Dir
+	if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+		t.Fatalf("'terraform init' failed (%v): %v", cmdErr, string(out))
+	}
+
+	fmt.Fprintf(stdout, "running `tf2pulumi`...\n")
+
+	// Generate an index.ts file using `tf2pulumi`.
+	indexTS, err := os.Create(filepath.Join(test.runOpts.Dir, test.targetFile()))
+	if err != nil {
+		t.Fatalf("failed to create index.ts: %v", err)
+	}
+	defer contract.IgnoreClose(indexTS)
+
+	var args []string
+	if test.convertOpts.FilterName != "" {
+		args = append(args, "--filter-resource-names="+test.convertOpts.FilterName)
+	}
+	args = append(args, "--target-language="+test.language)
+
+	var stderr bytes.Buffer
+	cmd = exec.Command("tf2pulumi", args...)
+	cmd.Dir = test.runOpts.Dir
+	cmd.Stdout, cmd.Stderr = indexTS, &stderr
+	if err = cmd.Run(); err != nil {
+		t.Fatalf("failed to generate Pulumi program (%v):\n%v", err, stderr.String())
+	}
+}
+
+//
+// Everything below this point is sugar for manually constructing a `Test` structure.
+//
+
+// RunTest defines a new test case residing in the given directory. It takes zero or more options which can be used
+// to further configure the test harness.
+func RunTest(t *testing.T, dir string, opts ...TestOptionsFunc) {
+	test := Test{}
+	// Apply common defaults.
+	test.Options.Compile = true
+	test.Options.FilterName = "name"
+	test.RunOptions = &integration.ProgramTestOptions{
+		Dir:                  dir,
+		ExpectRefreshChanges: true,
+	}
+	for _, opt := range opts {
+		opt(t, &test)
+	}
+
+	test.Run(t)
+}
+
+// TestOptionsFunc is a function that can be used as an option to `RunTest`.
+type TestOptionsFunc func(*testing.T, *Test)
+
+// Compile sets whether or not this test case should be executed by Pulumi after being processed by tf2pulumi. Defaults
+// to false if not provided.
+func Compile(value bool) TestOptionsFunc {
+	return func(_ *testing.T, test *Test) { test.Options.Compile = value }
+}
+
+// FilterName sets whether or not tf2pulumi should filter properties with the given name for this test case. Defaults
+// to the empty string, which will cause no properties to be filtered.
+func FilterName(value string) TestOptionsFunc {
+	return func(_ *testing.T, test *Test) { test.Options.FilterName = value }
+}
+
+// RequireAWSRegion reads an AWS region from the `AWS_REGION` environment variable and sets the value of the
+// `aws:region` Pulumi config key to the contents of the environment variable. If the environment variable is not set,
+// the test is skipped.
+func RequireAWSRegion() TestOptionsFunc {
+	return func(t *testing.T, test *Test) {
+		region := os.Getenv("AWS_REGION")
+		if region == "" {
+			t.Skipf("Skipping test due to missing AWS_REGION environment variable")
+		}
+		if test.RunOptions.Config == nil {
+			test.RunOptions.Config = make(map[string]string)
+		}
+		test.RunOptions.Config["aws:region"] = region
+	}
+}
+
+// Skip skips the test for the given reason.
+func Skip(reason string) TestOptionsFunc {
+	return func(_ *testing.T, test *Test) { test.Options.Skip = reason }
+}
+
+// Python sets up a new context that also accepts any number of test options, but applies those test options only when
+// running with the Python target. Options that affect the Pulumi CLI integration test framework are ignored.
+func Python(opts ...TestOptionsFunc) TestOptionsFunc {
+	return func(t *testing.T, test *Test) {
+		child := Test{}
+		child.RunOptions = &integration.ProgramTestOptions{}
+		for _, opt := range opts {
+			opt(t, &child)
+		}
+		test.Python = &child.Options
+	}
+}
+
+// SkipPython skips the Python target for the given test.
+func SkipPython() TestOptionsFunc {
+	return Python(Skip("Python not yet implemented"))
 }

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -260,22 +260,6 @@ func FilterName(value string) TestOptionsFunc {
 	return func(_ *testing.T, test *Test) { test.Options.FilterName = value }
 }
 
-// RequireAWSRegion reads an AWS region from the `AWS_REGION` environment variable and sets the value of the
-// `aws:region` Pulumi config key to the contents of the environment variable. If the environment variable is not set,
-// the test is skipped.
-func RequireAWSRegion() TestOptionsFunc {
-	return func(t *testing.T, test *Test) {
-		region := os.Getenv("AWS_REGION")
-		if region == "" {
-			t.Skipf("Skipping test due to missing AWS_REGION environment variable")
-		}
-		if test.RunOptions.Config == nil {
-			test.RunOptions.Config = make(map[string]string)
-		}
-		test.RunOptions.Config["aws:region"] = region
-	}
-}
-
 // Skip skips the test for the given reason.
 func Skip(reason string) TestOptionsFunc {
 	return func(_ *testing.T, test *Test) { test.Options.Skip = reason }


### PR DESCRIPTION
In anticipation of a Python backend, this commit beefs up the integration test harness a little bit to be able to run tests against multiple targets simultaneously without having to explicitly do it as part of the test definition.

This PR also contains a limited "sugar" around the test harness which presents a fluent-ish interface for defining and running tests. The sugary interface cuts down on a lot of boilerplate code needed to write and run a tf2pulumi test, so I think it's a usability win (since I'm planning to bring up new tests as I bring up Python), but I'll defer to Pat's thoughts on aesthetics.

Worth noting is that the integration test framework is now configured to run all tests with the Python backend, although every test explicitly skips Python because the Python backend doesn't do anything.

This PR is split into two commits. The first commit contains just the modifications to the integration test framework itself, while the second commit contains changes to the tests themselves to adhere to the framework.

