### PR TITLE
Add intrinsic helpers

### DIFF
--- a/gen/nodejs/assign_names_apply.go
+++ b/gen/nodejs/assign_names_apply.go
@@ -102,7 +102,7 @@ func (nt *applyNameTable) disambiguateArgName(n *il.BoundVariableAccess, bestNam
 	}
 }
 
-func (g *generator) assignApplyArgNames(applyArgs []il.BoundExpr, then il.BoundExpr) []string {
+func (g *generator) assignApplyArgNames(applyArgs []*il.BoundVariableAccess, then il.BoundExpr) []string {
 	nt := &applyNameTable{
 		g:          g,
 		assigned:   make(map[string]bool),
@@ -128,13 +128,13 @@ func (g *generator) assignApplyArgNames(applyArgs []il.BoundExpr, then il.BoundE
 
 	argNames := make([]string, len(applyArgs))
 	for i, arg := range applyArgs {
-		bestName := nt.bestArgName(arg.(*il.BoundVariableAccess))
+		bestName := nt.bestArgName(arg)
 		argNames[i], nt.nameCounts[bestName] = bestName, nt.nameCounts[bestName]+1
 	}
 
 	for i, argName := range argNames {
 		if nt.nameCounts[argName] > 1 {
-			argName = nt.disambiguateArgName(applyArgs[i].(*il.BoundVariableAccess), argName)
+			argName = nt.disambiguateArgName(applyArgs[i], argName)
 			if nt.nameCounts[argName] == 0 {
 				nt.nameCounts[argName] = 1
 			}

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -225,7 +225,7 @@ func TestAssignApplyNames(t *testing.T) {
 
 	g := &generator{nameTable: assignNames(m, true)}
 
-	args := []il.BoundExpr{
+	args := []*il.BoundVariableAccess{
 		boundRef("local.name", il.TypeString.OutputOf(), m.Locals["name"]),
 		boundRef("var.name", il.TypeString.OutputOf(), m.Variables["name"]),
 		boundRef("var.region", il.TypeString.OutputOf(), m.Variables["region"]),

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -87,7 +87,7 @@ func (g *generator) genApplyOutput(w io.Writer, n *il.BoundVariableAccess) {
 func (g *generator) genApply(w io.Writer, n *il.BoundCall) {
 	// Extract the list of outputs and the continuation expression from the `__apply` arguments.
 	applyArgs, then := il.ParseApplyCall(n)
-	g.applyArgs, g.applyArgNames = applyArgs, g.assignApplyArgNames(g.applyArgs, then)
+	g.applyArgs, g.applyArgNames = applyArgs, g.assignApplyArgNames(applyArgs, then)
 
 	if len(g.applyArgs) == 1 {
 		// If we only have a single output, just generate a normal `.apply`.

--- a/gen/nodejs/intrinsics.go
+++ b/gen/nodejs/intrinsics.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"github.com/hashicorp/hil/ast"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+const (
+	// intrinsicDataSource is the name of the data source intrinsic.
+	intrinsicDataSource = "__dataSource"
+)
+
+// newDataSourceCall creates a new call to the data source intrinsic that represents an invocation of the specified
+// data source function with the given input properties.
+func newDataSourceCall(functionName string, inputs il.BoundNode) *il.BoundCall {
+	return &il.BoundCall{
+		HILNode:  &ast.Call{Func: intrinsicDataSource},
+		ExprType: il.TypeMap,
+		Args: []il.BoundExpr{
+			&il.BoundLiteral{
+				ExprType: il.TypeString,
+				Value:    functionName,
+			},
+			&il.BoundPropertyExpr{
+				NodeType: il.TypeMap,
+				Value:    inputs,
+			},
+		},
+	}
+}
+
+// parseDataSourceCall extracts the name of the data source function and the input properties for its invocation from
+// a call to the data source intrinsic.
+func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode) {
+	contract.Assert(c.HILNode.Func == intrinsicDataSource)
+	return c.Args[0].(*il.BoundLiteral).Value.(string), c.Args[1].(*il.BoundPropertyExpr).Value
+}

--- a/gen/nodejs/intrinsics_test.go
+++ b/gen/nodejs/intrinsics_test.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/pulumi/tf2pulumi/il"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntrinsicDataSource(t *testing.T) {
+	function := "aws.getFunction"
+	inputs := &il.BoundMapProperty{}
+
+	c := newDataSourceCall(function, inputs)
+	assert.Equal(t, intrinsicDataSource, c.HILNode.Func)
+	assert.Equal(t, il.TypeMap, c.ExprType)
+	assert.Equal(t, 2, len(c.Args))
+
+	function2, inputs2 := parseDataSourceCall(c)
+	assert.Equal(t, function, function2)
+	assert.Equal(t, inputs, inputs2)
+}

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -334,11 +334,7 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		if v.Field != "workspace" {
 			return nil, errors.Errorf("unsupported key 'terraform.%s'", v.Field)
 		}
-		return &BoundCall{
-			HILNode:  &ast.Call{Func: "__getStack"},
-			ExprType: TypeString,
-			Args:     nil,
-		}, nil
+		return NewGetStackCall(), nil
 	case *config.UserVariable:
 		// "var."
 		if v.Elem != "" {

--- a/il/coercions.go
+++ b/il/coercions.go
@@ -16,8 +16,6 @@ package il
 
 import (
 	"strconv"
-
-	"github.com/hashicorp/hil/ast"
 )
 
 // makeCoercion inserts a call to the `__coerce` intrinsic if one is required to convert the given expression to the
@@ -68,11 +66,7 @@ func makeCoercion(n BoundNode, toType Type) BoundNode {
 		return n
 	}
 
-	return &BoundCall{
-		HILNode:  &ast.Call{Func: "__coerce"},
-		ExprType: toType,
-		Args:     []BoundExpr{e},
-	}
+	return NewCoerceCall(e, toType)
 }
 
 // AddCoercions inserts calls to the `__coerce` intrinsic in cases where a list or map element's type disagrees with

--- a/il/intrinsics.go
+++ b/il/intrinsics.go
@@ -1,0 +1,130 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package il
+
+import (
+	"github.com/hashicorp/hil/ast"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+const (
+	// IntrinsicApply is the name of the apply intrinsic.
+	IntrinsicApply = "__apply"
+	// IntrinsicApplyArg is the name of the apply arg intrinsic.
+	IntrinsicApplyArg = "__applyArg"
+	// IntrinsicArchive is the name of the archive intrinsic.
+	IntrinsicArchive = "__archive"
+	// IntrinsicAsset is the name of the asset intrinsic.
+	IntrinsicAsset = "__asset"
+	// IntrinsicCoerce is the name of the coerce intrinsic.
+	IntrinsicCoerce = "__coerce"
+	// IntrinsicGetStack is the name of the get stack intrinsic.
+	IntrinsicGetStack = "__getStack"
+)
+
+// NewApplyCall returns a new IL tree that represents a call to IntrinsicApply.
+func NewApplyCall(args []*BoundVariableAccess, then BoundExpr) *BoundCall {
+	exprs := make([]BoundExpr, len(args)+1)
+	for i, a := range args {
+		exprs[i] = a
+	}
+	exprs[len(exprs)-1] = then
+
+	return &BoundCall{
+		HILNode:  &ast.Call{Func: IntrinsicApply},
+		ExprType: then.Type().OutputOf(),
+		Args:     exprs,
+	}
+}
+
+// ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.
+func ParseApplyCall(c *BoundCall) (applyArgs []*BoundVariableAccess, then BoundExpr) {
+	contract.Assert(c.HILNode.Func == IntrinsicApply)
+
+	args := make([]*BoundVariableAccess, len(c.Args)-1)
+	for i, a := range c.Args[:len(args)] {
+		args[i] = a.(*BoundVariableAccess)
+	}
+
+	return args, c.Args[len(c.Args)-1]
+}
+
+// NewApplyArgCall returns a new IL tree that represents a call to IntrinsicApplyArg.
+func NewApplyArgCall(argIndex int, argType Type) *BoundCall {
+	contract.Assert(!argType.IsOutput())
+	return &BoundCall{
+		HILNode:  &ast.Call{Func: IntrinsicApplyArg},
+		ExprType: argType,
+		Args:     []BoundExpr{&BoundLiteral{ExprType: TypeNumber, Value: argIndex}},
+	}
+}
+
+// ParseapplyArgCall extracts the argument index from a call to the apply arg intrinsic.
+func ParseApplyArgCall(c *BoundCall) int {
+	contract.Assert(c.HILNode.Func == IntrinsicApplyArg)
+	return c.Args[0].(*BoundLiteral).Value.(int)
+}
+
+// NewArchiveCall creates a call to IntrinsicArchive.
+func NewArchiveCall(arg BoundExpr) *BoundCall {
+	return &BoundCall{
+		HILNode:  &ast.Call{Func: IntrinsicArchive},
+		ExprType: TypeUnknown,
+		Args:     []BoundExpr{arg},
+	}
+}
+
+// ParseArchiveCall extracts the single argument expression from a call to the archive intrinsic.
+func ParseArchiveCall(c *BoundCall) (arg BoundExpr) {
+	contract.Assert(c.HILNode.Func == IntrinsicArchive)
+	return c.Args[0]
+}
+
+// NewAssetCall creates a call to IntrinsicArchive.
+func NewAssetCall(arg BoundExpr) *BoundCall {
+	return &BoundCall{
+		HILNode:  &ast.Call{Func: IntrinsicAsset},
+		ExprType: TypeUnknown,
+		Args:     []BoundExpr{arg},
+	}
+}
+
+// ParseAssetCall extracts the single argument expression from a call to the asset intrinsic.
+func ParseAssetCall(c *BoundCall) (arg BoundExpr) {
+	contract.Assert(c.HILNode.Func == IntrinsicAsset)
+	return c.Args[0]
+}
+
+// NewCoerceCall creates a call to IntrisicCoerce, which is used to represent the coercion of a value from one type to
+// another.
+func NewCoerceCall(value BoundExpr, toType Type) *BoundCall {
+	return &BoundCall{
+		HILNode:  &ast.Call{Func: IntrinsicCoerce},
+		ExprType: toType,
+		Args:     []BoundExpr{value},
+	}
+}
+
+// ParseCoerceCall extracts the value being coerced and the type to which it is being coerced from a call to the coerce
+// intrinsic.
+func ParseCoerceCall(c *BoundCall) (value BoundExpr, toType Type) {
+	contract.Assert(c.HILNode.Func == IntrinsicCoerce)
+	return c.Args[0], c.ExprType
+}
+
+// NewGetStackCall creates a call to IntrinsicGetStack.
+func NewGetStackCall() *BoundCall {
+	return &BoundCall{HILNode: &ast.Call{Func: IntrinsicGetStack}, ExprType: TypeString}
+}

--- a/il/intrinsics_test.go
+++ b/il/intrinsics_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package il
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntrinsicApply(t *testing.T) {
+	args := []*BoundVariableAccess{
+		&BoundVariableAccess{},
+		&BoundVariableAccess{},
+		&BoundVariableAccess{},
+	}
+	then := &BoundLiteral{}
+
+	c := NewApplyCall(args, then)
+	assert.Equal(t, IntrinsicApply, c.HILNode.Func)
+	assert.Equal(t, then.Type().OutputOf(), c.ExprType)
+	assert.Equal(t, len(args)+1, len(c.Args))
+
+	args2, then2 := ParseApplyCall(c)
+	assert.EqualValues(t, args, args2)
+	assert.Equal(t, then, then2)
+}
+
+func TestIntrinsicApplyArg(t *testing.T) {
+	idx, typ := 3, TypeString
+
+	c := NewApplyArgCall(idx, typ)
+	assert.Equal(t, IntrinsicApplyArg, c.HILNode.Func)
+	assert.Equal(t, typ, c.Type())
+	assert.Equal(t, 1, len(c.Args))
+
+	assert.Equal(t, idx, ParseApplyArgCall(c))
+}
+
+func TestIntrinsicArchive(t *testing.T) {
+	arg := &BoundLiteral{}
+
+	c := NewArchiveCall(arg)
+	assert.Equal(t, IntrinsicArchive, c.HILNode.Func)
+	assert.Equal(t, TypeUnknown, c.Type())
+	assert.Equal(t, 1, len(c.Args))
+
+	assert.Equal(t, arg, ParseArchiveCall(c))
+}
+
+func TestIntrinsicAsset(t *testing.T) {
+	arg := &BoundLiteral{}
+
+	c := NewAssetCall(arg)
+	assert.Equal(t, IntrinsicAsset, c.HILNode.Func)
+	assert.Equal(t, TypeUnknown, c.Type())
+	assert.Equal(t, 1, len(c.Args))
+
+	assert.Equal(t, arg, ParseAssetCall(c))
+}
+
+func TestIntrinsicCoerce(t *testing.T) {
+	value, toType := &BoundLiteral{}, TypeNumber
+
+	c := NewCoerceCall(value, toType)
+	assert.Equal(t, IntrinsicCoerce, c.HILNode.Func)
+	assert.Equal(t, toType, c.Type())
+	assert.Equal(t, 1, len(c.Args))
+
+	value2, toType2 := ParseCoerceCall(c)
+	assert.Equal(t, value, value2)
+	assert.Equal(t, toType, toType2)
+}
+
+func TestIntrinsicGetStack(t *testing.T) {
+	c := NewGetStackCall()
+	assert.Equal(t, IntrinsicGetStack, c.HILNode.Func)
+	assert.Equal(t, TypeString, c.Type())
+	assert.Equal(t, 0, len(c.Args))
+}


### PR DESCRIPTION
The intent of these helpers is to make working with intrinsic calls more
reliable and more convenient. The general approach is to add three
constructs for a particular intrinsic:

1. A constant to represent the intrinsic's name
2. A factory function to create calls to the intrinsic
3. A parser function that extracts the relevant values from the
   intrinsic