### PR TITLE
Use schema information to elide autonames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## v0.4.9 (Unreleased)
 
+## Improvements
+
+- Auto-named properties can now be optionally filtered from the generated source using schema information. This gives
+  better results than the previous filtering, which sometimes removed properties that overlapped with auto-named
+  properties but were not themselves auto-names.
+
 ## v0.4.8 (Released February 26, 2019)
 
 ## Improvements

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1162,11 +1162,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:533bc4b59a1d73ec2d0d9e958de72a50bcc63442f35c94264a4d3b9f7589f7d3"
+  digest = "1:696f317bd45042dc179408273e861c7f890ce3c0184281962861c45accff9b5c"
   name = "github.com/pulumi/pulumi-terraform"
   packages = ["pkg/tfbridge"]
   pruneopts = ""
-  revision = "e9a2d394b36b1c0722c2edec01cf663495d44bc4"
+  revision = "386f2690e79acc345902578db5e3dc93ec02dcc7"
 
 [[projects]]
   branch = "master"

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -73,13 +73,15 @@ func Convert(opts Options) error {
 
 	// Filter resource name properties if requested.
 	if opts.FilterResourceNames {
-		if opts.ResourceNameProperty == "" {
-			return errors.New("ResourceNameProperty must not be empty if FilterResourceNames is true")
-		}
+		filterAutoNames := opts.ResourceNameProperty == ""
 		for _, g := range gs {
 			for _, r := range g.Resources {
 				if r.Config.Mode == config.ManagedResourceMode {
 					il.FilterProperties(r, func(key string, _ il.BoundNode) bool {
+						if filterAutoNames {
+							sch := r.Schemas().PropertySchemas(key).Pulumi
+							return sch == nil || sch.Default == nil || !sch.Default.AutoNamed
+						}
 						return key != opts.ResourceNameProperty
 					})
 				}


### PR DESCRIPTION
If `--filter-auto-names` is specified on the command line, filter
values for properties that are marked as autogenerated names from
the generated code.