### PR TITLE
Refactor genf and friends

### DIFF
--- a/gen/emit.go
+++ b/gen/emit.go
@@ -1,0 +1,144 @@
+package gen
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+// HILGenerator is an interface that
+type HILGenerator interface {
+	// GenArithmetic generates code for the indicated arithmetic node to the given writer.
+	GenArithmetic(w io.Writer, v *il.BoundArithmetic)
+	// GenCall generates code for the indicated call node to the given writer.
+	GenCall(w io.Writer, v *il.BoundCall)
+	// GenConditional generates code for the indicated conditional node to the given writer.
+	GenConditional(w io.Writer, v *il.BoundConditional)
+	// GenError generates code for the indicated error node to the given writer.
+	GenError(w io.Writer, v *il.BoundError)
+	// GenIndex generates code for the indicated index node to the given writer.
+	GenIndex(w io.Writer, v *il.BoundIndex)
+	// GenListProperty generates code for the indicated list property to the given writer.
+	GenListProperty(w io.Writer, v *il.BoundListProperty)
+	// GenLiteral generates code for the indicated literal node to the given writer.
+	GenLiteral(w io.Writer, v *il.BoundLiteral)
+	// GenMapProperty generates code for the indicated map property to the given writer.
+	GenMapProperty(w io.Writer, v *il.BoundMapProperty)
+	// GenOutput generates code for the indicated output node to the given writer.
+	GenOutput(w io.Writer, v *il.BoundOutput)
+	// GenPropertyValue generates code for the indicated property value node to the given writer.
+	GenPropertyValue(w io.Writer, v *il.BoundPropertyValue)
+	// GenVariableAccess generates code for the indicated variable access node to the given writer.
+	GenVariableAccess(w io.Writer, v *il.BoundVariableAccess)
+}
+
+// Emitter is a convenience type that implements a number of common utilities used to emit source code. It implements
+// the io.Writer interface.
+type Emitter struct {
+	// The current indent level as a string.
+	Indent string
+
+	// The HILGenerator to use in {G,Fg}en{,f}
+	g HILGenerator
+	// The writer to output to.
+	w io.Writer
+}
+
+// NewEmitter creates a new emitter targeting the given io.Writer that will use the given HILGenerator when generating
+// code.
+func NewEmitter(w io.Writer, g HILGenerator) *Emitter {
+	return &Emitter{w: w, g: g}
+}
+
+// Write writes the given bytes to the emitter's destination.
+func (e *Emitter) Write(b []byte) (int, error) {
+	return e.w.Write(b)
+}
+
+// indented bumps the current indentation level, invokes the given function, and then resets the indentation level to
+// its prior value.
+func (e *Emitter) Indented(f func()) {
+	e.Indent += "    "
+	f()
+	e.Indent = e.Indent[:len(e.Indent)-4]
+}
+
+// print prints one or more values to the generator's output stream.
+func (e *Emitter) Print(a ...interface{}) {
+	_, err := fmt.Fprint(e.w, a...)
+	contract.IgnoreError(err)
+}
+
+// println prints one or more values to the generator's output stream, followed by a newline.
+func (e *Emitter) Println(a ...interface{}) {
+	e.Print(a...)
+	e.Print("\n")
+}
+
+// prinft prints a formatted message to the generator's output stream.
+func (e *Emitter) Printf(format string, a ...interface{}) {
+	_, err := fmt.Fprintf(e.w, format, a...)
+	contract.IgnoreError(err)
+}
+
+// Gen is shorthand for Fgen(e, vs...).
+func (e *Emitter) Gen(vs ...interface{}) {
+	e.Fgen(e.w, vs...)
+}
+
+// Fgen generates code for a list of strings and expression trees. The former are written directly to the destination;
+// the latter are recursively generated using the appropriate gen* functions.
+func (e *Emitter) Fgen(w io.Writer, vs ...interface{}) {
+	for _, v := range vs {
+		switch v := v.(type) {
+		case string:
+			_, err := fmt.Fprint(w, v)
+			contract.IgnoreError(err)
+		case *il.BoundArithmetic:
+			e.g.GenArithmetic(w, v)
+		case *il.BoundCall:
+			e.g.GenCall(w, v)
+		case *il.BoundConditional:
+			e.g.GenConditional(w, v)
+		case *il.BoundIndex:
+			e.g.GenIndex(w, v)
+		case *il.BoundLiteral:
+			e.g.GenLiteral(w, v)
+		case *il.BoundOutput:
+			e.g.GenOutput(w, v)
+		case *il.BoundPropertyValue:
+			e.g.GenPropertyValue(w, v)
+		case *il.BoundVariableAccess:
+			e.g.GenVariableAccess(w, v)
+		case *il.BoundListProperty:
+			e.g.GenListProperty(w, v)
+		case *il.BoundMapProperty:
+			e.g.GenMapProperty(w, v)
+		case *il.BoundError:
+			e.g.GenError(w, v)
+		default:
+			contract.Failf("unexpected type in gen: %T", v)
+		}
+	}
+}
+
+// Genf is shorthand for Fgenf(e, format, args...)
+func (e *Emitter) Genf(format string, args ...interface{}) {
+	e.Fgenf(e.w, format, args...)
+}
+
+// Fgenf generates code using a format string and its arguments. Any arguments that are BoundNode values are wrapped in
+// a FormatFunc that calls the appropriate recursive generation function. This allows for the composition of standard
+// format strings with expression/property code gen (e.e. `e.genf(w, ".apply(__arg0 => %v)", then)`, where `then` is
+// an expression tree).
+func (e *Emitter) Fgenf(w io.Writer, format string, args ...interface{}) {
+	for i := range args {
+		if node, ok := args[i].(il.BoundNode); ok {
+			args[i] = FormatFunc(func(f fmt.State, c rune) { e.Fgen(f, node) })
+		}
+	}
+	fmt.Fprintf(w, format, args...)
+}

--- a/gen/nodejs/archive.go
+++ b/gen/nodejs/archive.go
@@ -37,14 +37,14 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 			return "", err
 		}
 
-		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.FileAsset(%s),\n", g.indent, path, path)
+		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.FileAsset(%s),\n", g.Indent, path, path)
 	} else if sourceDir, ok := r.Properties.Elements["source_dir"]; ok {
 		path, _, err := g.computeProperty(sourceDir, indent, count)
 		if err != nil {
 			return "", err
 		}
 
-		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.FileAsset(%s),\n", g.indent, path, path)
+		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.FileAsset(%s),\n", g.Indent, path, path)
 	} else if sourceContent, ok := r.Properties.Elements["source_content"]; ok {
 		filename, ok := r.Properties.Elements["source_filename"]
 		if !ok {
@@ -60,7 +60,7 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 			return "", err
 		}
 
-		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.StringAsset(%s),\n", g.indent, path, content)
+		fmt.Fprintf(buf, "%s    %s: new pulumi.asset.StringAsset(%s),\n", g.Indent, path, content)
 	} else if source, ok := r.Properties.Elements["source"]; ok {
 		list, ok := source.(*il.BoundListProperty)
 		if !ok {
@@ -91,10 +91,10 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 				return "", err
 			}
 
-			fmt.Fprintf(buf, "%s    %s: new pulumi.asset.StringAsset(%s),\n", g.indent, path, content)
+			fmt.Fprintf(buf, "%s    %s: new pulumi.asset.StringAsset(%s),\n", g.Indent, path, content)
 		}
 	}
-	fmt.Fprintf(buf, "%s}", g.indent)
+	fmt.Fprintf(buf, "%s}", g.Indent)
 	return buf.String(), nil
 }
 
@@ -113,7 +113,7 @@ func (g *generator) generateArchive(r *il.ResourceNode) error {
 		}
 
 		// Generate an asset archive.
-		g.printf("const %s = new pulumi.asset.AssetArchive(%s);", name, inputs)
+		g.Printf("const %s = new pulumi.asset.AssetArchive(%s);", name, inputs)
 	} else {
 		// Otherwise we need to Generate multiple resources in a loop.
 		count, _, err := g.computeProperty(r.Count, false, "")
@@ -125,10 +125,10 @@ func (g *generator) generateArchive(r *il.ResourceNode) error {
 			return err
 		}
 
-		g.printf("const %s: pulumi.asset.AssetArchive[] = [];\n", name)
-		g.printf("for (let i = 0; i < %s; i++) {\n", count)
-		g.printf("    %s.push(new pulumi.asset.AssetArchive(%s));\n", name, inputs)
-		g.printf("}")
+		g.Printf("const %s: pulumi.asset.AssetArchive[] = [];\n", name)
+		g.Printf("for (let i = 0; i < %s; i++) {\n", count)
+		g.Printf("    %s.push(new pulumi.asset.AssetArchive(%s));\n", name, inputs)
+		g.Printf("}")
 	}
 
 	return nil

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -81,6 +81,7 @@ func TestLowerToLiteral(t *testing.T) {
 		rootPath: ".",
 		module:   &il.Graph{Tree: module.NewTree("foo", &config.Config{Dir: "./foo/bar"})},
 	}
+	g.Emitter = gen.NewEmitter(nil, g)
 
 	p, err := g.lowerToLiterals(prop)
 	assert.NoError(t, err)

--- a/gen/nodejs/http.go
+++ b/gen/nodejs/http.go
@@ -48,9 +48,9 @@ func (g *generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count str
 
 	buf := &bytes.Buffer{}
 	buf.WriteString("{\n")
-	fmt.Fprintf(buf, "%s    url: %s,\n", g.indent, url)
-	fmt.Fprintf(buf, "%s    headers: %s,\n", g.indent, requestHeaders)
-	fmt.Fprintf(buf, "%s}", g.indent)
+	fmt.Fprintf(buf, "%s    url: %s,\n", g.Indent, url)
+	fmt.Fprintf(buf, "%s    headers: %s,\n", g.Indent, requestHeaders)
+	fmt.Fprintf(buf, "%s}", g.Indent)
 	return buf.String(), nil
 }
 
@@ -66,7 +66,7 @@ func (g *generator) generateHTTP(r *il.ResourceNode) error {
 			return err
 		}
 
-		g.printf("const %s = pulumi.output(rpn(%s).promise());", name, inputs)
+		g.Printf("const %s = pulumi.output(rpn(%s).promise());", name, inputs)
 	} else {
 		count, _, err := g.computeProperty(r.Count, false, "")
 		if err != nil {
@@ -77,10 +77,10 @@ func (g *generator) generateHTTP(r *il.ResourceNode) error {
 			return err
 		}
 
-		g.printf("const %s: pulumi.Output<string>[] = [];\n", name)
-		g.printf("for (let i = 0; i < %s; i++) {\n", count)
-		g.printf("    %s.push(pulumi.output(rpn(%s).promise()));\n", name, inputs)
-		g.printf("}")
+		g.Printf("const %s: pulumi.Output<string>[] = [];\n", name)
+		g.Printf("for (let i = 0; i < %s; i++) {\n", count)
+		g.Printf("    %s.push(pulumi.output(rpn(%s).promise()));\n", name, inputs)
+		g.Printf("}")
 	}
 
 	return nil

--- a/gen/nodejs/intrinsics.go
+++ b/gen/nodejs/intrinsics.go
@@ -37,7 +37,7 @@ func newDataSourceCall(functionName string, inputs il.BoundNode) *il.BoundCall {
 				ExprType: il.TypeString,
 				Value:    functionName,
 			},
-			&il.BoundPropertyExpr{
+			&il.BoundPropertyValue{
 				NodeType: il.TypeMap,
 				Value:    inputs,
 			},
@@ -49,5 +49,5 @@ func newDataSourceCall(functionName string, inputs il.BoundNode) *il.BoundCall {
 // a call to the data source intrinsic.
 func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode) {
 	contract.Assert(c.HILNode.Func == intrinsicDataSource)
-	return c.Args[0].(*il.BoundLiteral).Value.(string), c.Args[1].(*il.BoundPropertyExpr).Value
+	return c.Args[0].(*il.BoundLiteral).Value.(string), c.Args[1].(*il.BoundPropertyValue).Value
 }

--- a/gen/nodejs/properties.go
+++ b/gen/nodejs/properties.go
@@ -25,10 +25,10 @@ import (
 )
 
 // genListProperty generates code for as single list property.
-func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
+func (g *generator) GenListProperty(w io.Writer, n *il.BoundListProperty) {
 	switch len(n.Elements) {
 	case 0:
-		g.gen(w, "[]")
+		g.Fgen(w, "[]")
 	case 1:
 		// We can ignore comments in this case: the comment extractor will never associate comments with a
 		// single-element list.
@@ -38,47 +38,47 @@ func (g *generator) genListProperty(w io.Writer, n *il.BoundListProperty) {
 			//
 			// TODO: if there is a list element that is dynamically a list, that also needs to be flattened. This is
 			// only knowable at runtime and will require a helper.
-			g.genf(w, "%v", v)
+			g.Fgenf(w, "%v", v)
 		} else {
-			g.genf(w, "[%v]", v)
+			g.Fgenf(w, "[%v]", v)
 		}
 	default:
-		g.gen(w, "[")
-		g.indented(func() {
+		g.Fgen(w, "[")
+		g.Indented(func() {
 			for _, v := range n.Elements {
-				g.genf(w, "\n")
+				g.Fgenf(w, "\n")
 				g.genLeadingComment(w, v.Comments())
-				g.genf(w, "%s", g.indent)
+				g.Fgenf(w, "%s", g.Indent)
 
 				// TF flattens list elements that are themselves lists into the parent list.
 				//
 				// TODO: if there is a list element that is dynamically a list, that also needs to be flattened. This is
 				// only knowable at runtime and will require a helper.
 				if v.Type().IsList() {
-					g.gen(w, "...")
+					g.Fgen(w, "...")
 				}
-				g.genf(w, "%v,", v)
+				g.Fgenf(w, "%v,", v)
 
 				g.genTrailingComment(w, v.Comments())
 			}
 		})
-		g.gen(w, "\n", g.indent, "]")
+		g.Fgen(w, "\n", g.Indent, "]")
 	}
 }
 
 // genMapProperty generates code for a single map property.
-func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
+func (g *generator) GenMapProperty(w io.Writer, n *il.BoundMapProperty) {
 	if len(n.Elements) == 0 {
-		g.gen(w, "{}")
+		g.Fgen(w, "{}")
 	} else {
 		useExactKeys := n.Schemas.TF != nil && n.Schemas.TF.Type == schema.TypeMap
 
-		g.gen(w, "{")
-		g.indented(func() {
+		g.Fgen(w, "{")
+		g.Indented(func() {
 			for _, k := range gen.SortedKeys(n.Elements) {
 				v := n.Elements[k]
 
-				g.genf(w, "\n")
+				g.Fgenf(w, "\n")
 				g.genLeadingComment(w, v.Comments())
 
 				propSch, key := n.Schemas.PropertySchemas(k), k
@@ -87,11 +87,11 @@ func (g *generator) genMapProperty(w io.Writer, n *il.BoundMapProperty) {
 				} else if !isLegalIdentifier(key) {
 					key = fmt.Sprintf("%q", key)
 				}
-				g.genf(w, "%s%s: %v,", g.indent, key, v)
+				g.Fgenf(w, "%s%s: %v,", g.Indent, key, v)
 
 				g.genTrailingComment(w, v.Comments())
 			}
 		})
-		g.gen(w, "\n", g.indent, "}")
+		g.Fgen(w, "\n", g.Indent, "}")
 	}
 }

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -567,9 +567,9 @@ func (n *BoundError) dump(d *dumper) {
 func (n *BoundError) isNode() {}
 func (n *BoundError) isExpr() {}
 
-// BoundPropertyExpr wraps a BoundMapProperty or BoundListProperty in a BoundExpr. This is intended primarily for the
+// BoundPropertyValue wraps a BoundMapProperty or BoundListProperty in a BoundExpr. This is intended primarily for the
 // use of transforms that must pass bound properties to intrinsics.
-type BoundPropertyExpr struct {
+type BoundPropertyValue struct {
 	// The type of the node.
 	NodeType Type
 	// Comments is the set of comments associated with this node, if any.
@@ -579,24 +579,24 @@ type BoundPropertyExpr struct {
 }
 
 // Type returns the type of the expression.
-func (n *BoundPropertyExpr) Type() Type {
+func (n *BoundPropertyValue) Type() Type {
 	return n.NodeType
 }
 
 // Comments returns the comments attached to this node, if any.
-func (n *BoundPropertyExpr) Comments() *Comments {
+func (n *BoundPropertyValue) Comments() *Comments {
 	return n.NodeComments
 }
 
 // setComments attaches the given comments to this node.
-func (n *BoundPropertyExpr) setComments(c *Comments) {
+func (n *BoundPropertyValue) setComments(c *Comments) {
 	n.NodeComments = c
 }
 
-func (n *BoundPropertyExpr) isNode() {}
-func (n *BoundPropertyExpr) isExpr() {}
+func (n *BoundPropertyValue) isNode() {}
+func (n *BoundPropertyValue) isExpr() {}
 
-func (n *BoundPropertyExpr) dump(d *dumper) {
+func (n *BoundPropertyValue) dump(d *dumper) {
 	d.dump("(propertyExpr ", fmt.Sprintf("%v", n.Type()))
 	d.indented(func() {
 		d.dump("\n", d.indent, n.Value)

--- a/il/boundTree_visitor.go
+++ b/il/boundTree_visitor.go
@@ -129,7 +129,7 @@ func visitBoundOutput(n *BoundOutput, pre, post BoundNodeVisitor) (BoundNode, er
 	return post(n)
 }
 
-func visitBoundPropertyExpr(n *BoundPropertyExpr, pre, post BoundNodeVisitor) (BoundNode, error) {
+func visitBoundPropertyValue(n *BoundPropertyValue, pre, post BoundNodeVisitor) (BoundNode, error) {
 	value, err := VisitBoundNode(n.Value, pre, post)
 	if err != nil {
 		return nil, err
@@ -225,8 +225,8 @@ func VisitBoundNode(n BoundNode, pre, post BoundNodeVisitor) (BoundNode, error) 
 		return visitBoundMapProperty(n, pre, post)
 	case *BoundOutput:
 		return visitBoundOutput(n, pre, post)
-	case *BoundPropertyExpr:
-		return visitBoundPropertyExpr(n, pre, post)
+	case *BoundPropertyValue:
+		return visitBoundPropertyValue(n, pre, post)
 	case *BoundVariableAccess:
 		return post(n)
 	default:


### PR DESCRIPTION
Move these methods into a utility type in the gen package. This will
allow a little bit more code sharing between the NodeJS and Python
backends.