### PR TITLE
Lower proxied applies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.5.0 (Unreleased)
+
+- Added a command line option, `-target-sdk-version`,  to indicate the SDK version targeted by the generated code.
+  Note that this option defaults to `0.17.1`, which will by default generate code that is not compatible with
+  older SDKs.
+- Simplified the generation of output property accesses and string interpolations when targeting SDKs newer than
+  version 0.17.0.
+
 ## v0.4.9 (Released March 1, 2019)
 
 ## Improvements

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -125,6 +125,8 @@ type Options struct {
 	Logger *log.Logger
 	// The target language.
 	TargetLanguage string
+	// The target SDK version.
+	TargetSDKVersion string
 }
 
 type noCredentials struct{}
@@ -163,7 +165,7 @@ func buildGraphs(tree *module.Tree, isRoot bool, opts Options) ([]*il.Graph, err
 func newGenerator(projectName string, opts Options) (gen.Generator, error) {
 	switch opts.TargetLanguage {
 	case LanguageTypescript:
-		return nodejs.New(projectName, opts.Writer), nil
+		return nodejs.New(projectName, opts.TargetSDKVersion, opts.Writer)
 	case LanguagePython:
 		return python.New(projectName, opts.Writer), nil
 	default:

--- a/gen/emit.go
+++ b/gen/emit.go
@@ -66,19 +66,19 @@ func (e *Emitter) Indented(f func()) {
 	e.Indent = e.Indent[:len(e.Indent)-4]
 }
 
-// print prints one or more values to the generator's output stream.
+// Print prints one or more values to the generator's output stream.
 func (e *Emitter) Print(a ...interface{}) {
 	_, err := fmt.Fprint(e.w, a...)
 	contract.IgnoreError(err)
 }
 
-// println prints one or more values to the generator's output stream, followed by a newline.
+// Println prints one or more values to the generator's output stream, followed by a newline.
 func (e *Emitter) Println(a ...interface{}) {
 	e.Print(a...)
 	e.Print("\n")
 }
 
-// prinft prints a formatted message to the generator's output stream.
+// Printf prints a formatted message to the generator's output stream.
 func (e *Emitter) Printf(format string, a ...interface{}) {
 	_, err := fmt.Fprintf(e.w, format, a...)
 	contract.IgnoreError(err)

--- a/gen/nodejs/intrinsics.go
+++ b/gen/nodejs/intrinsics.go
@@ -24,6 +24,8 @@ import (
 const (
 	// intrinsicDataSource is the name of the data source intrinsic.
 	intrinsicDataSource = "__dataSource"
+	// inttrinsicInterpolate is the name of the interpolate intrinsic.
+	intrinsicInterpolate = "__interpolate"
 )
 
 // newDataSourceCall creates a new call to the data source intrinsic that represents an invocation of the specified
@@ -50,4 +52,14 @@ func newDataSourceCall(functionName string, inputs il.BoundNode) *il.BoundCall {
 func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode) {
 	contract.Assert(c.HILNode.Func == intrinsicDataSource)
 	return c.Args[0].(*il.BoundLiteral).Value.(string), c.Args[1].(*il.BoundPropertyValue).Value
+}
+
+// newInterpolateCall creates a new call to the interpolate intrinsic that represents a template literal that uses the
+// pulumi.interpolate function.
+func newInterpolateCall(args []il.BoundExpr) *il.BoundCall {
+	return &il.BoundCall{
+		HILNode:  &ast.Call{Func: intrinsicInterpolate},
+		ExprType: il.TypeString.OutputOf(),
+		Args:     args,
+	}
 }

--- a/gen/nodejs/lower.go
+++ b/gen/nodejs/lower.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/tf2pulumi/il"
 )
 
@@ -54,5 +55,104 @@ func (g *generator) lowerToLiterals(prop il.BoundNode) (il.BoundNode, error) {
 		}
 	}
 
+	return il.VisitBoundNode(prop, il.IdentityVisitor, rewriter)
+}
+
+// parseProxyApply attempts to match the given parsed apply against the pattern (call __applyArg 0). If the call
+// matches, it returns the BoundVariableAccess that corresponds to argument zero, which can then be generated as a
+// proxied apply call.
+func parseProxyApply(args []*il.BoundVariableAccess, then il.BoundExpr) (*il.BoundVariableAccess, bool) {
+	if len(args) != 1 {
+		return nil, false
+	}
+
+	thenCall, ok := then.(*il.BoundCall)
+	if !ok || thenCall.HILNode.Func != il.IntrinsicApplyArg {
+		return nil, false
+	}
+
+	argIndex := il.ParseApplyArgCall(thenCall)
+	if argIndex != 0 {
+		return nil, false
+	}
+
+	return args[argIndex], true
+}
+
+// hasApplyArgDescendant returns true if the given BoundExpr has any descendant that is a call to __applyArg. This is a
+// helper for parseInterpolate.
+func hasApplyArgDescendant(expr il.BoundExpr) bool {
+	has := false
+	_, err := il.VisitBoundNode(expr, il.IdentityVisitor, func(n il.BoundNode) (il.BoundNode, error) {
+		if c, ok := n.(*il.BoundCall); ok && c.HILNode.Func == il.IntrinsicApplyArg {
+			has = true
+		}
+		return n, nil
+	})
+	contract.Assert(err == nil)
+	return has
+}
+
+// parseInterpolate attempts to match the given parsed apply against the pattern (output /* mix of expressions and calls to __applyArg).
+//
+// A legal expression for the match is any expression that does not contain any calls to __applyArg: an expression that
+// does contain such calls requires an apply.
+//
+// If the call matches, parseInterpolate returns an appropriate call to the __interpolate intrinsic with a mix of
+// expressions and variable accesses that correspond to the __applyArg calls.
+func parseInterpolate(args []*il.BoundVariableAccess, then il.BoundExpr) (*il.BoundCall, bool) {
+	thenOutput, ok := then.(*il.BoundOutput)
+	if !ok {
+		return nil, false
+	}
+
+	exprs := make([]il.BoundExpr, len(thenOutput.Exprs))
+	for i, expr := range thenOutput.Exprs {
+		call, isCall := expr.(*il.BoundCall)
+		switch {
+		case isCall && call.HILNode.Func == il.IntrinsicApplyArg:
+			exprs[i] = args[il.ParseApplyArgCall(call)]
+		case !hasApplyArgDescendant(expr):
+			exprs[i] = expr
+		default:
+			return nil, false
+		}
+	}
+
+	return newInterpolateCall(exprs), true
+}
+
+// lowerProxyApplies lowers certain calls to the apply intrinsic into proxied property accesses and/or calls to the
+// pulumi.interpolate function. Concretely, this boils down to rewriting the following shapes
+// - (call __apply (resource variable access) (call __applyArg 0))
+// - (call __apply (resource variable access 0) ... (resource variable access n) (output /* some mix of expressions and calls to __applyArg))
+// into (respectively)
+// - (resource variable access)
+// - (call __interpolate /* mix of literals and variable accesses that correspond to the __applyArg calls)
+//
+// The generated code requires that the target version of `@pulumi/pulumi` supports output proxies.
+func (g *generator) lowerProxyApplies(prop il.BoundNode) (il.BoundNode, error) {
+	rewriter := func(n il.BoundNode) (il.BoundNode, error) {
+		// Ignore the node if it is not a call to the apply intrinsic.
+		apply, ok := n.(*il.BoundCall)
+		if !ok || apply.HILNode.Func != il.IntrinsicApply {
+			return n, nil
+		}
+
+		// Parse the apply call.
+		args, then := il.ParseApplyCall(apply)
+
+		// Attempt to match (call __apply (rvar) (call __applyArg 0))
+		if v, ok := parseProxyApply(args, then); ok {
+			return v, nil
+		}
+
+		// Attempt to match (call __apply (rvar 0) ... (rvar n) (output /* mix of literals and calls to __applyArg)
+		if v, ok := parseInterpolate(args, then); ok {
+			return v, nil
+		}
+
+		return n, nil
+	}
 	return il.VisitBoundNode(prop, il.IdentityVisitor, rewriter)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 
 require (
 	git.apache.org/thrift.git v0.12.0 // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/chzyer/logex v1.1.11-0.20160617073814-96a4d311aa9b // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/hashicorp/hcl v1.0.0

--- a/main.go
+++ b/main.go
@@ -63,7 +63,9 @@ Pulumi TypeScript program that describes the same resource graph.`,
 	flag.BoolVar(&filterAutoNames, "filter-auto-names", false,
 		"when set, properties that are auto-generated names will be removed from all resources")
 	flag.StringVar(&opts.TargetLanguage, "target-language", "typescript",
-		"sets the target language")
+		"sets the language to target")
+	flag.StringVar(&opts.TargetSDKVersion, "target-sdk-version", "0.17.1",
+		"sets the language SDK version to target")
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of tf2pulumi",

--- a/tests/terraform/aws/ec2/index.base.ts
+++ b/tests/terraform/aws/ec2/index.base.ts
@@ -16,7 +16,7 @@ const ubuntu = pulumi.output(aws.getAmi({
     owners: ["099720109477"],
 }));
 const web = new aws.ec2.Instance("web", {
-    ami: ubuntu.apply(ubuntu => ubuntu.id),
+    ami: ubuntu.id,
     instanceType: "t2.micro",
     tags: {
         Name: "HelloWorld",


### PR DESCRIPTION
There are two major changes here:
1. Generate normal property access expressions for `apply` calls that
   can be handled by proxy. This is exactly the set of applies that look
   like `r.prop.apply(p => p.nested)`. When enabled, these will be
   emitted as `r.prop.nested`.
2. Generate calls to `pulumi.interpolate` for applies that involve the
   interpolation of multiple properties and literals. This is the set of
   applies that look like ```r.prop.apply(p => `foo: ${p}` ``` or
   ```pulumi.all([r.foo, s.bar]).apply(([f, b]) => `f: ${f}, b: ${b}`)```.
   These will be emitted as ```pulumi.interpolate`foo: ${r.prop}` ``` and
   ```pulumi.interpolate`f: ${r.foo}, b: ${s.bar}` ```, respectively.

These features can be disabled by setting the target SDK version to
anything below 0.17.0 using the `-target-sdk-version` option in the CLI.
The default SDK version is 0.17.1.