### PR TITLE
Fix a few array- and optional-related bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD (Unreleased)
+
+- Fix bad code generation for variable accesses that involve index expressions or optional properties.
+
 ## v0.5.1 (Released August 14, 2019)
 
 - Added a command line option, `-typescript.synchronous-data-sources`, to indicate that the generated code should

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -140,6 +140,9 @@ func (g *generator) genNestedPropertyAccess(w io.Writer, v *il.BoundVariableAcce
 			}
 		} else {
 			g.Fgenf(w, ".%s", tfbridge.TerraformToPulumiName(e, sch.TF, false))
+			if sch.TF != nil && sch.TF.Optional {
+				g.Fgen(w, "!")
+			}
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/tf2pulumi
 go 1.12
 
 replace (
+	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 	github.com/Nvveen/Gotty => github.com/ijc25/Gotty v0.0.0-20170406111628-a8b993ba6abd
 	github.com/census-instrumentation/opencensus-proto v0.1.0 => github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8
 	github.com/golang/glog => github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4

--- a/il/schemas.go
+++ b/il/schemas.go
@@ -15,6 +15,8 @@
 package il
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
 )
@@ -28,10 +30,14 @@ type Schemas struct {
 	Pulumi *tfbridge.SchemaInfo
 }
 
-// PropertySchemas returns the Schemas for the child property with the given name. This is only valid if the current
-// Schemas describe a map property.
+// PropertySchemas returns the Schemas for the child property with the given name. If the name is an integer, this
+// function returns the value of a call to ElemSchemas.
 func (s Schemas) PropertySchemas(key string) Schemas {
 	var propSch Schemas
+
+	if _, err := strconv.ParseInt(key, 0, 0); err == nil {
+		return s.ElemSchemas()
+	}
 
 	if s.TFRes != nil && s.TFRes.Schema != nil {
 		propSch.TF = s.TFRes.Schema[key]

--- a/tests/terraform/gcp/gcp_test.go
+++ b/tests/terraform/gcp/gcp_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/tf2pulumi/tests/terraform"
+)
+
+// RequireGCPConfig reads configuration for `gcp:project`, `gcp:region`, and `gcp:zone` from the `GOOGLE_PROJECT`,
+// `GOOGLE_REGION`, and `GOOGLE_ZONE` environment variables, respectively. If any of these environment variables are
+// not set, the test is skipped.
+func RequireGCPConfig() terraform.TestOptionsFunc {
+	return func(t *testing.T, test *terraform.Test) {
+		// Set the configurations.
+		project := os.Getenv("GOOGLE_PROJECT")
+		if project == "" {
+			t.Skipf("Skipping test due to missing GOOGLE_PROJECT variable")
+		}
+		region := os.Getenv("GOOGLE_REGION")
+		if region == "" {
+			t.Skipf("Skipping test due to missing GOOGLE_REGION variable")
+		}
+		zone := os.Getenv("GOOGLE_ZONE")
+		if zone == "" {
+			t.Skipf("Skipping test due to missing GOOGLE_ZONE variable")
+		}
+		if test.RunOptions.Config == nil {
+			test.RunOptions.Config = make(map[string]string)
+		}
+		test.RunOptions.Config["gcp:project"] = project
+		test.RunOptions.Config["gcp:region"] = region
+		test.RunOptions.Config["gcp:zone"] = zone
+	}
+}
+
+func RunGCPTest(t *testing.T, dir string, opts ...terraform.TestOptionsFunc) {
+	opts = append(opts, RequireGCPConfig())
+	terraform.RunTest(t, dir, opts...)
+}
+
+func TestRecordSet(t *testing.T) {
+	RunGCPTest(t, "record_set", terraform.SkipPython(), terraform.Compile(false))
+}

--- a/tests/terraform/gcp/record_set/Pulumi.yaml
+++ b/tests/terraform/gcp/record_set/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: asg
+runtime: nodejs
+description: ASG Example
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/tests/terraform/gcp/record_set/index.base.ts
+++ b/tests/terraform/gcp/record_set/index.base.ts
@@ -1,0 +1,25 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+
+const frontendInstance = new gcp.compute.Instance("frontend", {
+    bootDisk: {
+        initializeParams: {
+            image: "debian-cloud/debian-9",
+        },
+    },
+    machineType: "g1-small",
+    networkInterfaces: [{
+        accessConfigs: [{}],
+        network: "default",
+    }],
+    zone: "us-central1-b",
+});
+const prod = new gcp.dns.ManagedZone("prod", {
+    dnsName: "prod.mydomain.com.",
+});
+const frontendRecordSet = new gcp.dns.RecordSet("frontend", {
+    managedZone: prod.name,
+    rrdatas: [frontendInstance.networkInterfaces.apply(networkInterfaces => networkInterfaces[0].accessConfigs![0].natIp!)],
+    ttl: 300,
+    type: "A",
+});

--- a/tests/terraform/gcp/record_set/main.tf
+++ b/tests/terraform/gcp/record_set/main.tf
@@ -1,0 +1,31 @@
+resource "google_dns_record_set" "frontend" {
+  name = "frontend.${google_dns_managed_zone.prod.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = "${google_dns_managed_zone.prod.name}"
+
+  rrdatas = ["${google_compute_instance.frontend.network_interface.0.access_config.0.nat_ip}"]
+}
+
+resource "google_compute_instance" "frontend" {
+  name         = "frontend"
+  machine_type = "g1-small"
+  zone         = "us-central1-b"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network       = "default"
+    access_config = {}
+  }
+}
+
+resource "google_dns_managed_zone" "prod" {
+  name     = "prod-zone"
+  dns_name = "prod.mydomain.com."
+}

--- a/tests/terraform/gcp/record_set/package.json
+++ b/tests/terraform/gcp/record_set/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "asg",
+    "devDependencies": {
+        "@types/node": "latest",
+        "@types/sprintf-js": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/gcp": "latest",
+        "sprintf-js": "latest"
+    }
+}

--- a/tests/terraform/gcp/record_set/tsconfig.json
+++ b/tests/terraform/gcp/record_set/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
- Properly fetch list element schemas when `il.Schema.PropertySchemas`
  is invoked with an integer key
- Do not generate lifted property accesses for accesses that involve
  array indexes, as array index expressions cannot be lifted
- Handle optional fields by generating a `!` expression

Fixes #113.