### PR TITLE
Annotate generated code with source locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 - Fix bad code generation for variable accesses that involve index expressions or optional properties.
 - Support first-class providers when targeting Node.JS.
 - Fix ordering for resources and module instantiations with explicit providers.
-= Do not generate empty argument bags for nilary data source invocations.
+- Do not generate empty argument bags for nilary data source invocations.
+- Add a command line option, `-record-locations`, that indicates that each resource, data source, etc. in the
+  generated code should be annotated with the location of its original definition in the source Terraform config.
 
 ## v0.5.1 (Released August 14, 2019)
 

--- a/gen/nodejs/testdata/test_ordering/index.ts
+++ b/gen/nodejs/testdata/test_ordering/index.ts
@@ -5,6 +5,7 @@ const config = new pulumi.Config();
 // Accept the AWS region as input.
 const awsRegion = config.get("awsRegion") || "us-west-2";
 
+// Create a provider for account data.
 const accountData = new aws.Provider("account_data", {
     region: awsRegion,
 });

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -130,6 +130,14 @@ func (d *dumper) dump(vs ...interface{}) {
 	}
 }
 
+// Location defines a location in a source file.
+type Location struct {
+	// Path is the path of the file relative to the root of the module.
+	Path string
+	// Line is the line number in the source file.
+	Line int
+}
+
 // Comments represents the set of comments associated with a node.
 type Comments struct {
 	// Leading is the lines of the comment (sans comment tokens) that precedes a node, if any. Line endings (if any)

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -130,14 +130,6 @@ func (d *dumper) dump(vs ...interface{}) {
 	}
 }
 
-// Location defines a location in a source file.
-type Location struct {
-	// Path is the path of the file relative to the root of the module.
-	Path string
-	// Line is the line number in the source file.
-	Line int
-}
-
 // Comments represents the set of comments associated with a node.
 type Comments struct {
 	// Leading is the lines of the comment (sans comment tokens) that precedes a node, if any. Line endings (if any)

--- a/il/graph_comments.go
+++ b/il/graph_comments.go
@@ -22,9 +22,15 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/hashicorp/terraform/config"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
+
+// locatable is an interface shared by the IL's top-level nodes.
+type locatable interface {
+	setLocation(p token.Pos)
+}
 
 // commentable is an interface shared by the IL's top-level nodes (e.g. ResourceNode, OutputNode) and its bound
 // nodes.
@@ -74,8 +80,8 @@ func (b *builder) extractComments(c *config.Config) error {
 }
 
 // extractFileComments extracts comments from a particular HCL source file.
-func (b *builder) extractFileComments(path string) error {
-	t, err := ioutil.ReadFile(path)
+func (b *builder) extractFileComments(filePath string) error {
+	t, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
@@ -85,12 +91,12 @@ func (b *builder) extractFileComments(path string) error {
 		return err
 	}
 
-	b.extractHCLComments(f)
+	b.extractHCLComments(f, path.Base(filePath))
 	return nil
 }
 
 // extractHCLComments extracts comments from the given HCL file.
-func (b *builder) extractHCLComments(f *ast.File) {
+func (b *builder) extractHCLComments(f *ast.File, path string) {
 	root, ok := f.Node.(*ast.ObjectList)
 	if !ok {
 		b.logf("unexpected type for HCL root node '%T'; skipping file...", f.Node)
@@ -101,71 +107,74 @@ func (b *builder) extractHCLComments(f *ast.File) {
 	for _, n := range root.Items {
 		switch n.Keys[0].Token.Value().(string) {
 		case "variable":
-			b.extractVariableComments(n)
+			b.extractVariableComments(n, path)
 		case "provider":
-			b.extractProviderComments(n)
+			b.extractProviderComments(n, path)
 		case "module":
-			b.extractModuleComments(n)
+			b.extractModuleComments(n, path)
 		case "resource":
-			b.extractResourceComments(n, config.ManagedResourceMode)
+			b.extractResourceComments(n, path, config.ManagedResourceMode)
 		case "data":
-			b.extractResourceComments(n, config.DataResourceMode)
+			b.extractResourceComments(n, path, config.DataResourceMode)
 		case "locals":
 			if object, ok := n.Val.(*ast.ObjectType); ok {
 				for _, ln := range object.List.Items {
-					b.extractLocalComments(ln)
+					b.extractLocalComments(ln, path)
 				}
 			} else {
 				b.logf("unexpected locals type '%T'; skipping node...", n.Val)
 			}
 		case "output":
-			b.extractOutputComments(n)
+			b.extractOutputComments(n, path)
 		}
 	}
 }
 
 // extractVariableComments extracts comments from the given HCL object item and attaches them to the corresponding
 // variable node, if any exists.
-func (b *builder) extractVariableComments(item *ast.ObjectItem) {
+func (b *builder) extractVariableComments(item *ast.ObjectItem, path string) {
 	name := item.Keys[1].Token.Value().(string)
 	v, ok := b.variables[name]
 	if !ok {
 		return
 	}
 
+	attachLocation(v, item.Pos(), path)
 	attachComments(v, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, &BoundMapProperty{Elements: map[string]BoundNode{"default": v.DefaultValue}})
 }
 
 // extractProviderComments extracts comments from the given HCL object item and attaches them to the corresponding
 // provider node, if any exists.
-func (b *builder) extractProviderComments(item *ast.ObjectItem) {
+func (b *builder) extractProviderComments(item *ast.ObjectItem, path string) {
 	name := item.Keys[1].Token.Value().(string)
 	p, ok := b.providers[name]
 	if !ok {
 		return
 	}
 
+	attachLocation(p, item.Pos(), path)
 	attachComments(p, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, p.Properties)
 }
 
 // extractModuleComments extracts comments from the given HCL object item and attaches them to the corresponding
 // module node, if any exists.
-func (b *builder) extractModuleComments(item *ast.ObjectItem) {
+func (b *builder) extractModuleComments(item *ast.ObjectItem, path string) {
 	name := item.Keys[1].Token.Value().(string)
 	m, ok := b.modules[name]
 	if !ok {
 		return
 	}
 
+	attachLocation(m, item.Pos(), path)
 	attachComments(m, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, m.Properties)
 }
 
 // extractResourceComments extracts comments from the given HCL object item and attaches them to the corresponding
 // resource node, if any exists.
-func (b *builder) extractResourceComments(item *ast.ObjectItem, mode config.ResourceMode) {
+func (b *builder) extractResourceComments(item *ast.ObjectItem, path string, mode config.ResourceMode) {
 	cfg := &config.Resource{
 		Mode: mode,
 		Name: item.Keys[2].Token.Value().(string),
@@ -176,32 +185,35 @@ func (b *builder) extractResourceComments(item *ast.ObjectItem, mode config.Reso
 		return
 	}
 
+	attachLocation(r, item.Pos(), path)
 	attachComments(r, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, r.Properties)
 }
 
 // extractLocalComments extracts comments from the given HCL object item and attaches them to the corresponding
 // local node, if any exists.
-func (b *builder) extractLocalComments(item *ast.ObjectItem) {
+func (b *builder) extractLocalComments(item *ast.ObjectItem, path string) {
 	name := item.Keys[0].Token.Value().(string)
 	l, ok := b.locals[name]
 	if !ok {
 		return
 	}
 
+	attachLocation(l, item.Pos(), path)
 	attachComments(l, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, l.Value)
 }
 
 // extractOutputComments extracts comments from the given HCL object item and attaches them to the corresponding
 // output node, if any exists.
-func (b *builder) extractOutputComments(item *ast.ObjectItem) {
+func (b *builder) extractOutputComments(item *ast.ObjectItem, path string) {
 	name := item.Keys[1].Token.Value().(string)
 	o, ok := b.outputs[name]
 	if !ok {
 		return
 	}
 
+	attachLocation(o, item.Pos(), path)
 	attachComments(o, item.LeadComment, item.LineComment)
 	b.extractNodeComments(item.Val, &BoundMapProperty{Elements: map[string]BoundNode{"value": o.Value}})
 }
@@ -270,6 +282,12 @@ func (b *builder) extractNodeComments(node ast.Node, context BoundNode) {
 	default:
 		b.logf("unhandled ast type %T (%v)", node, node)
 	}
+}
+
+// attachLocation attaches the indicated location to a node and sets the file path appropriately.
+func attachLocation(n locatable, pos token.Pos, path string) {
+	pos.Filename = path
+	n.setLocation(pos)
 }
 
 // attachComments preprocesses the given leading and trailing comments (if any) and attaches them to the given node.

--- a/il/graph_comments_test.go
+++ b/il/graph_comments_test.go
@@ -147,23 +147,33 @@ output "security_group_name" {
 	assert.NoError(t, err)
 
 	v := b.variables["aws_region"]
+	assert.True(t, v.Location.IsValid())
+	assert.Equal(t, "main.tf", v.Location.Filename)
 	assertLeading(t, v.Comments, " Accept the AWS region as input.")
 	assertLeading(t, v.DefaultValue.Comments(), " Default to us-west-2")
 
 	p := b.providers["aws"]
+	assert.True(t, p.Location.IsValid())
+	assert.Equal(t, "main.tf", p.Location.Filename)
 	assertLeading(t, p.Comments, "Specify provider details")
 	assertLeading(t, p.Properties.Elements["region"].Comments(), " Pull the region from a variable")
 
 	l := b.locals["vpc"]
+	assert.True(t, l.Location.IsValid())
+	assert.Equal(t, "main.tf", l.Location.Filename)
 	assertLeading(t, l.Comments, " The VPC details")
 	lval := l.Value.(*BoundListProperty).Elements[0].(*BoundMapProperty)
 	assertLeading(t, lval.Elements["id"].Comments(), " The ID")
 
 	l = b.locals["region"]
+	assert.True(t, l.Location.IsValid())
+	assert.Equal(t, "main.tf", l.Location.Filename)
 	assertLeading(t, l.Comments, " The region, again")
 	assertTrailing(t, l.Comments, " why not")
 
 	vpc := b.resources["aws_vpc.default"]
+	assert.True(t, vpc.Location.IsValid())
+	assert.Equal(t, "main.tf", vpc.Location.Filename)
 	assertLeading(t, vpc.Comments, " Create a VPC.", "", " Note that the VPC has been tagged appropriately.")
 	assertTrailing(t, vpc.Properties.Elements["cidr_block"].Comments(), " Just one CIDR block")
 	assertTrailing(t, vpc.Properties.Elements["enable_dns_hostnames"].Comments(), " Definitely want DNS hostnames.")
@@ -172,6 +182,8 @@ output "security_group_name" {
 	assertLeading(t, tagsProp.Elements["Name"].Comments(), " Ensure that we tag this VPC with a Name.")
 
 	sg := b.resources["aws_security_group.default"]
+	assert.True(t, sg.Location.IsValid())
+	assert.Equal(t, "main.tf", sg.Location.Filename)
 	assertLeading(t, sg.Comments, " Create a security group.", "", " This group should allow SSH and HTTP access.")
 	ingressList := sg.Properties.Elements["ingress"].(*BoundListProperty)
 	sshAccess := ingressList.Elements[0].(*BoundMapProperty)
@@ -186,6 +198,8 @@ output "security_group_name" {
 	assertTrailing(t, outboundAccess.Elements["protocol"].Comments(), " All")
 
 	out := b.outputs["security_group_name"]
+	assert.True(t, out.Location.IsValid())
+	assert.Equal(t, "main.tf", out.Location.Filename)
 	assertLeading(t, out.Comments, " Output the SG name.", "", " We pull the name from the default SG.")
 	assertLeading(t, out.Value.Comments(), " Take the value from the default SG.")
 	assertTrailing(t, out.Value.Comments(), " Neat!")

--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"allows code generation to continue if the config references missing variables")
 	flag.BoolVar(&opts.AllowMissingComments, "allow-missing-comments", true,
 		"allows code generation to continue if there are errors extracting comments")
+	flag.BoolVar(&opts.AnnotateNodesWithLocations, "record-locations", false,
+		"annotate the generated code with original source locations for each resource")
 	flag.StringVar(&resourceNameProperty, "filter-resource-names", "",
 		"when set, the property with the given key will be removed from all resources")
 	flag.BoolVar(&filterAutoNames, "filter-auto-names", false,

--- a/tests/terraform/aws/ec2/index.base.ts
+++ b/tests/terraform/aws/ec2/index.base.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+// Originally defined at main.tf:5
 const ubuntu = aws.getAmi({
     filters: [
         {
@@ -15,6 +16,7 @@ const ubuntu = aws.getAmi({
     mostRecent: true,
     owners: ["099720109477"],
 });
+// Originally defined at main.tf:21
 const web = new aws.ec2.Instance("web", {
     ami: ubuntu.id,
     instanceType: "t2.micro",

--- a/tests/terraform/aws/lb-listener/index.base.ts
+++ b/tests/terraform/aws/lb-listener/index.base.ts
@@ -1,11 +1,17 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+// Originally defined at main.tf:12
 const pool = new aws.cognito.UserPool("pool", {});
+// Originally defined at main.tf:16
 const client = new aws.cognito.UserPoolClient("client", {});
+// Originally defined at main.tf:20
 const domain = new aws.cognito.UserPoolDomain("domain", {});
+// Originally defined at main.tf:4
 const frontEndLoadBalancer = new aws.lb.LoadBalancer("front_end", {});
+// Originally defined at main.tf:8
 const frontEndTargetGroup = new aws.lb.TargetGroup("front_end", {});
+// Originally defined at main.tf:24
 const frontEndListener = new aws.lb.Listener("front_end", {
     defaultActions: [
         {

--- a/tests/terraform/gcp/record_set/index.base.ts
+++ b/tests/terraform/gcp/record_set/index.base.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 
+// Originally defined at main.tf:11
 const frontendInstance = new gcp.compute.Instance("frontend", {
     bootDisk: {
         initializeParams: {
@@ -14,9 +15,11 @@ const frontendInstance = new gcp.compute.Instance("frontend", {
     }],
     zone: "us-central1-b",
 });
+// Originally defined at main.tf:28
 const prod = new gcp.dns.ManagedZone("prod", {
     dnsName: "prod.mydomain.com.",
 });
+// Originally defined at main.tf:1
 const frontendRecordSet = new gcp.dns.RecordSet("frontend", {
     managedZone: prod.name,
     rrdatas: [frontendInstance.networkInterfaces.apply(networkInterfaces => networkInterfaces[0].accessConfigs![0].natIp!)],

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -216,6 +216,7 @@ func (test *targetTest) generateCode(t *testing.T) {
 		args = append(args, "--filter-resource-names="+test.convertOpts.FilterName)
 	}
 	args = append(args, "--target-language="+test.language)
+	args = append(args, "--record-locations")
 
 	var stderr bytes.Buffer
 	cmd = exec.Command("tf2pulumi", args...)


### PR DESCRIPTION
Add a leading comment to each top-level node that records the location of its original definition in the source TF config. This feature must be enabled by passing the `-record-locations` flag on the command line.