### PR TITLE
Disambiguate names that collide with imports.

### DIFF
--- a/gen/nodejs/assign_names.go
+++ b/gen/nodejs/assign_names.go
@@ -198,11 +198,16 @@ func (nt *nameTable) assignResource(n *il.ResourceNode) {
 	nt.names[n], nt.assigned[name] = name, true
 }
 
-func assignNames(g *il.Graph, isRootModule bool) map[il.Node]string {
+func assignNames(g *il.Graph, importNames map[string]bool, isRootModule bool) map[il.Node]string {
 	nt := &nameTable{
 		names:        make(map[il.Node]string),
 		assigned:     make(map[string]bool),
 		isRootModule: isRootModule,
+	}
+
+	// Seed the set of assigned names with the names of imported modules.
+	for k := range importNames {
+		nt.assigned[k] = true
 	}
 
 	// Assign output names first: given a conflict between nodes, we always want the output node (if any) to win so

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -139,7 +139,7 @@ func TestAssignNames(t *testing.T) {
 		}),
 	}
 
-	names := assignNames(g, true)
+	names := assignNames(g, map[string]bool{}, true)
 
 	assert.Equal(t, "vpcId", names[g.Outputs["vpc_id"]])
 	assert.Equal(t, "securityGroupId", names[g.Outputs["security_group_id"]])
@@ -223,7 +223,7 @@ func TestAssignApplyNames(t *testing.T) {
 		}),
 	}
 
-	g := &generator{nameTable: assignNames(m, true)}
+	g := &generator{nameTable: assignNames(m, map[string]bool{}, true)}
 
 	args := []*il.BoundVariableAccess{
 		boundRef("local.name", il.TypeString.OutputOf(), m.Locals["name"]),


### PR DESCRIPTION
If a resource/provider/etc. name collides with the name of an import,
perform the usual disambiguation.