### PR TITLE
Improve generation order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   generated code should be annotated with the location of its original definition in the source Terraform config.
 - Fix code generation for `replace` when the pattern is a regex.
 - Generate resources that are instantiated at most exactly once using `if` statements rather than `for` loops.
+- Improve the generated code so that resources are generated in source order except where their dependencies dictate
+  otherwise.
 
 ## v0.5.1 (Released August 14, 2019)
 

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -1,0 +1,142 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/module"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/tf2pulumi/il"
+)
+
+type testGen struct {
+	t             *testing.T
+	currentModule *il.Graph
+	modules       map[*il.Graph][]il.Node
+}
+
+func (tg *testGen) GeneratePreamble(gs []*il.Graph) error {
+	assert.Nil(tg.t, tg.modules)
+
+	// Add entries to the module map for each graph.
+	tg.modules = map[*il.Graph][]il.Node{}
+	for _, g := range gs {
+		tg.modules[g] = nil
+	}
+	return nil
+}
+
+func (tg *testGen) BeginModule(g *il.Graph) error {
+	_, hasModule := tg.modules[g]
+	assert.True(tg.t, hasModule)
+	tg.currentModule = g
+	return nil
+}
+
+func (tg *testGen) EndModule(g *il.Graph) error {
+	assert.Equal(tg.t, tg.currentModule, g)
+	return nil
+}
+
+func (tg *testGen) GenerateProvider(p *il.ProviderNode) error {
+	tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], p)
+	return nil
+}
+
+func (tg *testGen) GenerateVariables(vs []*il.VariableNode) error {
+	for _, v := range vs {
+		tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], v)
+	}
+	return nil
+}
+
+func (tg *testGen) GenerateModule(m *il.ModuleNode) error {
+	tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], m)
+	return nil
+}
+
+func (tg *testGen) GenerateLocal(l *il.LocalNode) error {
+	tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], l)
+	return nil
+}
+
+func (tg *testGen) GenerateResource(r *il.ResourceNode) error {
+	tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], r)
+	return nil
+}
+
+func (tg *testGen) GenerateOutputs(os []*il.OutputNode) error {
+	for _, o := range os {
+		tg.modules[tg.currentModule] = append(tg.modules[tg.currentModule], o)
+	}
+	return nil
+}
+
+func loadConfig(t *testing.T, path string) *config.Config {
+	conf, err := config.LoadDir(path)
+	if err != nil {
+		t.Fatalf("could not load config at %s: %v", path, err)
+	}
+	return conf
+}
+
+func TestGenOrder(t *testing.T) {
+	conf := loadConfig(t, "testdata/test_gen_order")
+	g, err := il.BuildGraph(module.NewTree("main", conf), &il.BuildOptions{
+		AllowMissingProviders: true,
+	})
+	if err != nil {
+		t.Fatalf("could not build graph: %v", err)
+	}
+
+	lang := &testGen{t: t}
+	err = Generate([]*il.Graph{g}, lang)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(lang.modules))
+
+	mainNodes, ok := lang.modules[g]
+	assert.True(t, ok)
+	actualIDs := make([]string, len(mainNodes))
+	for i, n := range mainNodes {
+		actualIDs[i] = n.ID()
+	}
+
+	expectedNodes := []il.Node{
+		// Variables come first. All of these should be in source order.
+		g.Variables["vpc_id"],
+		g.Variables["availability_zone"],
+		g.Variables["region_numbers"],
+		g.Variables["az_numbers"],
+
+		// Inner nodes are next, in "best" order. First is the implicitly-configured AWS provider.
+		g.Providers["aws"],
+
+		// Next are the nodes from variables.tf, as they have no dependencies on nodes defined in other files. These
+		// nodes should be generated in source order.
+		g.Resources["data.aws_availability_zone.target"],
+		g.Resources["data.aws_vpc.target"],
+
+		// Next come the nodes from subnet.tf, because they depend on the nodes in variables.tf but on no other nodes
+		// defined in other files. The subnet and the route table are in source order, but the route table associtaion
+		// is out-of-order as it depends on the other two resources.
+		g.Resources["aws_subnet.main"],
+		g.Resources["aws_route_table.main"],
+		g.Resources["aws_route_table_association.main"],
+
+		// Next comes the single node from security_group.tf, as it depends on resources from both variables.tf and
+		// subnet.tf.
+		g.Resources["aws_security_group.az"],
+
+		// The outputs come last in source order.
+		g.Outputs["subnet_id"],
+		g.Outputs["security_group_id"],
+	}
+	expectedIDs := make([]string, len(expectedNodes))
+	for i, n := range expectedNodes {
+		expectedIDs[i] = n.ID()
+	}
+
+	assert.Equal(t, expectedIDs, actualIDs)
+}

--- a/gen/nodejs/testdata/test_comments/index.16.ts
+++ b/gen/nodejs/testdata/test_comments/index.16.ts
@@ -5,8 +5,6 @@ const config = new pulumi.Config();
 // Accept the AWS region as input.
 const awsRegion = config.get("awsRegion") || "us-west-2";
 
-// The region, again
-const region = awsRegion; // why not
 // Create a VPC.
 //
 // Note that the VPC has been tagged appropriately.
@@ -19,11 +17,24 @@ const defaultVpc = new aws.ec2.Vpc("default", {
         Name: "test",
     },
 });
+// Use some data sources.
+const defaultSubnetIds = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({
+    vpcId: id,
+}));
+const defaultAvailabilityZones = pulumi.output(aws.getAvailabilityZones());
+const defaultAvailabilityZone: pulumi.Output<aws.GetAvailabilityZoneResult>[] = [];
+for (let i = 0; i < defaultAvailabilityZones.apply(defaultAvailabilityZones => defaultAvailabilityZones.ids.length); i++) {
+    defaultAvailabilityZone.push(defaultAvailabilityZones.apply(defaultAvailabilityZones => aws.getAvailabilityZone({
+        zoneId: defaultAvailabilityZones.zoneIds[i],
+    })));
+}
 // The VPC details
 const vpc = [{
     // The ID
     id: defaultVpc.id,
 }];
+// The region, again
+const region = awsRegion; // why not
 // Create a security group.
 //
 // This group should allow SSH and HTTP access.
@@ -57,17 +68,6 @@ const defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
     },
     vpcId: vpc["id"],
 });
-const defaultAvailabilityZones = pulumi.output(aws.getAvailabilityZones());
-const defaultAvailabilityZone: pulumi.Output<aws.GetAvailabilityZoneResult>[] = [];
-for (let i = 0; i < defaultAvailabilityZones.apply(defaultAvailabilityZones => defaultAvailabilityZones.ids.length); i++) {
-    defaultAvailabilityZone.push(defaultAvailabilityZones.apply(defaultAvailabilityZones => aws.getAvailabilityZone({
-        zoneId: defaultAvailabilityZones.zoneIds[i],
-    })));
-}
-// Use some data sources.
-const defaultSubnetIds = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({
-    vpcId: id,
-}));
 
 // Output the SG name.
 //

--- a/gen/nodejs/testdata/test_comments/index.17.ts
+++ b/gen/nodejs/testdata/test_comments/index.17.ts
@@ -5,8 +5,6 @@ const config = new pulumi.Config();
 // Accept the AWS region as input.
 const awsRegion = config.get("awsRegion") || "us-west-2";
 
-// The region, again
-const region = awsRegion; // why not
 // Create a VPC.
 //
 // Note that the VPC has been tagged appropriately.
@@ -19,11 +17,24 @@ const defaultVpc = new aws.ec2.Vpc("default", {
         Name: "test",
     },
 });
+// Use some data sources.
+const defaultSubnetIds = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({
+    vpcId: id,
+}));
+const defaultAvailabilityZones = pulumi.output(aws.getAvailabilityZones());
+const defaultAvailabilityZone: pulumi.Output<aws.GetAvailabilityZoneResult>[] = [];
+for (let i = 0; i < defaultAvailabilityZones.apply(defaultAvailabilityZones => defaultAvailabilityZones.ids.length); i++) {
+    defaultAvailabilityZone.push(defaultAvailabilityZones.apply(defaultAvailabilityZones => aws.getAvailabilityZone({
+        zoneId: defaultAvailabilityZones.zoneIds[i],
+    })));
+}
 // The VPC details
 const vpc = [{
     // The ID
     id: defaultVpc.id,
 }];
+// The region, again
+const region = awsRegion; // why not
 // Create a security group.
 //
 // This group should allow SSH and HTTP access.
@@ -57,17 +68,6 @@ const defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
     },
     vpcId: vpc["id"],
 });
-const defaultAvailabilityZones = pulumi.output(aws.getAvailabilityZones());
-const defaultAvailabilityZone: pulumi.Output<aws.GetAvailabilityZoneResult>[] = [];
-for (let i = 0; i < defaultAvailabilityZones.apply(defaultAvailabilityZones => defaultAvailabilityZones.ids.length); i++) {
-    defaultAvailabilityZone.push(defaultAvailabilityZones.apply(defaultAvailabilityZones => aws.getAvailabilityZone({
-        zoneId: defaultAvailabilityZones.zoneIds[i],
-    })));
-}
-// Use some data sources.
-const defaultSubnetIds = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({
-    vpcId: id,
-}));
 
 // Output the SG name.
 //

--- a/gen/nodejs/testdata/test_conditionals/index.ts
+++ b/gen/nodejs/testdata/test_conditionals/index.ts
@@ -2,11 +2,42 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 const config = new pulumi.Config();
+const createSg = config.getBoolean("createSg") || false;
 // Accept the AWS region as input.
 const awsRegion = config.get("awsRegion") || "us-west-2";
-const createSg = config.getBoolean("createSg") || false;
 
 const inUsEast1 = (awsRegion === "us-east-1");
+// Optionally create a security group and attach some rules.
+let defaultSecurityGroup: aws.ec2.SecurityGroup | undefined;
+if (createSg) {
+    defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
+        description: "Default security group",
+    });
+}
+// SSH access from anywhere
+let ingress: aws.ec2.SecurityGroupRule | undefined;
+if (createSg) {
+    ingress = new aws.ec2.SecurityGroupRule("ingress", {
+        cidrBlocks: ["0.0.0.0/0"],
+        fromPort: 22,
+        protocol: "tcp",
+        securityGroupId: defaultSecurityGroup!.id,
+        toPort: 22,
+        type: "ingress",
+    });
+}
+// outbound internet access
+let egress: aws.ec2.SecurityGroupRule | undefined;
+if (createSg) {
+    egress = new aws.ec2.SecurityGroupRule("egress", {
+        cidrBlocks: ["0.0.0.0/0"],
+        fromPort: 0,
+        protocol: "-1",
+        securityGroupId: defaultSecurityGroup!.id,
+        toPort: 0,
+        type: "ingress",
+    });
+}
 // If we are in us-east-1, create an ec2 instance
 let web: aws.ec2.Instance | undefined;
 if (inUsEast1) {
@@ -28,36 +59,5 @@ if (!!(createWeb2)) {
         tags: {
             Name: `instance-${(createWeb2 % 2)}`,
         },
-    });
-}
-// Optionally create a security group and attach some rules.
-let defaultSecurityGroup: aws.ec2.SecurityGroup | undefined;
-if (createSg) {
-    defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
-        description: "Default security group",
-    });
-}
-// outbound internet access
-let egress: aws.ec2.SecurityGroupRule | undefined;
-if (createSg) {
-    egress = new aws.ec2.SecurityGroupRule("egress", {
-        cidrBlocks: ["0.0.0.0/0"],
-        fromPort: 0,
-        protocol: "-1",
-        securityGroupId: defaultSecurityGroup!.id,
-        toPort: 0,
-        type: "ingress",
-    });
-}
-// SSH access from anywhere
-let ingress: aws.ec2.SecurityGroupRule | undefined;
-if (createSg) {
-    ingress = new aws.ec2.SecurityGroupRule("ingress", {
-        cidrBlocks: ["0.0.0.0/0"],
-        fromPort: 22,
-        protocol: "tcp",
-        securityGroupId: defaultSecurityGroup!.id,
-        toPort: 22,
-        type: "ingress",
     });
 }

--- a/gen/testdata/test_gen_order/index.ts
+++ b/gen/testdata/test_gen_order/index.ts
@@ -1,0 +1,74 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// Originally defined at variables.tf:1
+const vpcId = config.require("vpcId");
+// Originally defined at variables.tf:3
+const availabilityZone = config.require("availabilityZone");
+// Originally defined at variables.tf:13
+const regionNumbers = config.get("regionNumbers") || {
+    "eu-west-1": 4,
+    "us-east-1": 1,
+    "us-west-1": 2,
+    "us-west-2": 3,
+};
+// Originally defined at variables.tf:22
+const azNumbers = config.get("azNumbers") || {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+    e: 5,
+    f: 6,
+    g: 7,
+    h: 8,
+    i: 9,
+    j: 10,
+    k: 11,
+    l: 12,
+    m: 13,
+    n: 14,
+};
+
+// Originally defined at variables.tf:5
+const targetAvailabilityZone = aws.getAvailabilityZone({
+    name: availabilityZone,
+});
+// Originally defined at variables.tf:9
+const targetVpc = aws.ec2.getVpc({
+    id: vpcId,
+});
+// Originally defined at subnet.tf:5
+const mainSubnet = new aws.ec2.Subnet("main", {
+    availabilityZone: availabilityZone,
+    cidrBlock: (() => {
+        throw "tf2pulumi error: NYI: call to cidrsubnet";
+        return (() => { throw "NYI: call to cidrsubnet"; })();
+    })(),
+    vpcId: vpcId,
+});
+// Originally defined at subnet.tf:11
+const mainRouteTable = new aws.ec2.RouteTable("main", {
+    vpcId: vpcId,
+});
+// Originally defined at subnet.tf:1
+const mainRouteTableAssociation = new aws.ec2.RouteTableAssociation("main", {
+    routeTableId: mainRouteTable.id,
+    subnetId: mainSubnet.id,
+});
+// Originally defined at security_group.tf:6
+const az = new aws.ec2.SecurityGroup("az", {
+    // name        = "az-${data.aws_availability_zone.target.name}"
+    description: `Open access within the AZ ${targetAvailabilityZone.name!}`,
+    ingress: [{
+        cidrBlocks: [mainSubnet.cidrBlock],
+        fromPort: 0,
+        protocol: "-1",
+        toPort: 0,
+    }],
+    vpcId: vpcId,
+});
+
+// Originally defined at outputs.tf:1
+export const subnetId = mainSubnet.id;

--- a/gen/testdata/test_gen_order/outputs.tf
+++ b/gen/testdata/test_gen_order/outputs.tf
@@ -1,0 +1,3 @@
+output "subnet_id" {
+  value = "${aws_subnet.main.id}"
+}

--- a/gen/testdata/test_gen_order/security_group.tf
+++ b/gen/testdata/test_gen_order/security_group.tf
@@ -1,0 +1,21 @@
+# NOTE: we do not specify names for any of the test resources in order to improve the reliability of our CI jobs
+# in the face of parallelism and leftover resources. Explicitly naming these resources can cause conflicts
+# between jobs that run concurrently or jobs that fail to clean up their resources. Pulumi will auto-name these
+# for us.
+
+resource "aws_security_group" "az" {
+  # name        = "az-${data.aws_availability_zone.target.name}"
+  description = "Open access within the AZ ${data.aws_availability_zone.target.name}"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["${aws_subnet.main.cidr_block}"]
+  }
+}
+
+output "security_group_id" {
+  value = "${aws_security_group.az.id}"
+}

--- a/gen/testdata/test_gen_order/subnet.tf
+++ b/gen/testdata/test_gen_order/subnet.tf
@@ -1,0 +1,13 @@
+resource "aws_route_table_association" "main" {
+  subnet_id      = "${aws_subnet.main.id}"
+  route_table_id = "${aws_route_table.main.id}"
+}
+resource "aws_subnet" "main" {
+  cidr_block        = "${cidrsubnet(data.aws_vpc.target.cidr_block, 4, lookup(var.az_numbers, data.aws_availability_zone.target.name_suffix))}"
+  vpc_id            = "${var.vpc_id}"
+  availability_zone = "${var.availability_zone}"
+}
+
+resource "aws_route_table" "main" {
+  vpc_id = "${var.vpc_id}"
+}

--- a/gen/testdata/test_gen_order/variables.tf
+++ b/gen/testdata/test_gen_order/variables.tf
@@ -1,0 +1,39 @@
+variable "vpc_id" {}
+
+variable "availability_zone" {}
+
+data "aws_availability_zone" "target" {
+  name = "${var.availability_zone}"
+}
+
+data "aws_vpc" "target" {
+  id = "${var.vpc_id}"
+}
+
+variable "region_numbers" {
+  default = {
+    us-east-1 = 1
+    us-west-1 = 2
+    us-west-2 = 3
+    eu-west-1 = 4
+  }
+}
+
+variable "az_numbers" {
+  default = {
+    a = 1
+    b = 2
+    c = 3
+    d = 4
+    e = 5
+    f = 6
+    g = 7
+    h = 8
+    i = 9
+    j = 10
+    k = 11
+    l = 12
+    m = 13
+    n = 14
+  }
+}

--- a/il/graph_comments.go
+++ b/il/graph_comments.go
@@ -29,6 +29,7 @@ import (
 
 // locatable is an interface shared by the IL's top-level nodes.
 type locatable interface {
+	GetLocation() token.Pos
 	setLocation(p token.Pos)
 }
 

--- a/tests/terraform/aws/lb-listener/index.base.ts
+++ b/tests/terraform/aws/lb-listener/index.base.ts
@@ -1,16 +1,16 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+// Originally defined at main.tf:4
+const frontEndLoadBalancer = new aws.lb.LoadBalancer("front_end", {});
+// Originally defined at main.tf:8
+const frontEndTargetGroup = new aws.lb.TargetGroup("front_end", {});
 // Originally defined at main.tf:12
 const pool = new aws.cognito.UserPool("pool", {});
 // Originally defined at main.tf:16
 const client = new aws.cognito.UserPoolClient("client", {});
 // Originally defined at main.tf:20
 const domain = new aws.cognito.UserPoolDomain("domain", {});
-// Originally defined at main.tf:4
-const frontEndLoadBalancer = new aws.lb.LoadBalancer("front_end", {});
-// Originally defined at main.tf:8
-const frontEndTargetGroup = new aws.lb.TargetGroup("front_end", {});
 // Originally defined at main.tf:24
 const frontEndListener = new aws.lb.Listener("front_end", {
     defaultActions: [


### PR DESCRIPTION
Rather than generating nodes in order by kind and then alphabetically by
name, implement a new algorithm that attempts to keep definitions
grouped by source file.

This algorithm works by building a worklist of files to generate and
iterating until the worklist is empty. On each iteration, the nodes from
the file with the the fewest references to nodes that have not yet been
generated and that are defined in other files is chosen for generation.
Within each file, nodes are ordered by their appearence in the original
source file. Out-of-order generation only occurs when it is necessary to
satisfy the requirement that nodes are generated in a valid topological
order.