### PR TITLE
Add support for custom timeouts and ignore changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Generate resources that are instantiated at most exactly once using `if` statements rather than `for` loops.
 - Improve the generated code so that resources are generated in source order except where their dependencies dictate
   otherwise.
+- Add support for the `timeouts` and `ignore_changes` properties.
 
 ## v0.5.1 (Released August 14, 2019)
 

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -666,7 +666,7 @@ func (g *generator) generateResource(r *il.ResourceNode) error {
 
 	if r.Timeouts != nil {
 		buf := &bytes.Buffer{}
-		g.Fgenf(buf, "timeouts: %s", r.Timeouts)
+		g.Fgenf(buf, "timeouts: %v", r.Timeouts)
 		resourceOptions = append(resourceOptions, buf.String())
 	}
 

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -670,6 +670,19 @@ func (g *generator) generateResource(r *il.ResourceNode) error {
 		resourceOptions = append(resourceOptions, buf.String())
 	}
 
+	if len(r.IgnoreChanges) != 0 {
+		buf := &bytes.Buffer{}
+		fmt.Fprintf(buf, "ignoreChanges: [")
+		for i, ic := range r.IgnoreChanges {
+			if i > 0 {
+				fmt.Fprintf(buf, ", ")
+			}
+			fmt.Fprintf(buf, "\"%s\"", ic)
+		}
+		fmt.Fprintf(buf, "]")
+		resourceOptions = append(resourceOptions, buf.String())
+	}
+
 	optionsBag := ""
 	if len(resourceOptions) != 0 {
 		optionsBag = fmt.Sprintf("{%s}", strings.Join(resourceOptions, ","))

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -664,6 +664,12 @@ func (g *generator) generateResource(r *il.ResourceNode) error {
 		resourceOptions = append(resourceOptions, buf.String())
 	}
 
+	if r.Timeouts != nil {
+		buf := &bytes.Buffer{}
+		g.Fgenf(buf, "timeouts: %s", r.Timeouts)
+		resourceOptions = append(resourceOptions, buf.String())
+	}
+
 	optionsBag := ""
 	if len(resourceOptions) != 0 {
 		optionsBag = fmt.Sprintf("{%s}", strings.Join(resourceOptions, ","))

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -210,3 +210,22 @@ func TestConditionals(t *testing.T) {
 	expectedText := readFile(t, "testdata/test_conditionals/index.ts")
 	assert.Equal(t, expectedText, b.String())
 }
+
+func TestMetaProperties(t *testing.T) {
+	conf := loadConfig(t, "testdata/test_meta_properties")
+	g, err := il.BuildGraph(module.NewTree("main", conf), &il.BuildOptions{
+		AllowMissingProviders: true,
+	})
+	if err != nil {
+		t.Fatalf("could not build graph: %v", err)
+	}
+
+	var b bytes.Buffer
+	lang, err := New("main", "1.0.0", true, &b)
+	assert.NoError(t, err)
+	err = gen.Generate([]*il.Graph{g}, lang)
+	assert.NoError(t, err)
+
+	expectedText := readFile(t, "testdata/test_meta_properties/index.ts")
+	assert.Equal(t, expectedText, b.String())
+}

--- a/gen/nodejs/testdata/test_meta_properties/index.ts
+++ b/gen/nodejs/testdata/test_meta_properties/index.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const r1 = new aws.ec2.Instance("r1", {}, {timeouts: {
+    create: "20m",
+    delete: "1h",
+    update: "5m",
+}});
+const r2 = new aws.ec2.Instance("r2", {}, {ignoreChanges: ["ami", "arn", "associatePublicIpAddress", "availabilityZone", "cpuCoreCount", "cpuThreadsPerCore", "creditSpecification", "disableApiTermination", "ebsBlockDevices", "ebsOptimized", "ephemeralBlockDevices", "getPasswordData", "hostId", "iamInstanceProfile", "instanceInitiatedShutdownBehavior", "instanceState", "instanceType", "ipv6AddressCount", "ipv6Addresses", "keyName", "monitoring", "networkInterfaceId", "networkInterfaces", "passwordData", "placementGroup", "primaryNetworkInterfaceId", "privateDns", "privateIp", "publicDns", "publicIp", "rootBlockDevice", "securityGroups", "sourceDestCheck", "subnetId", "tags", "tenancy", "userData", "userDataBase64", "volumeTags", "vpcSecurityGroupIds"]});
+const r3 = new aws.ec2.Instance("r3", {}, {ignoreChanges: ["ami", "networkInterfaces[0].networkInterfaceId", "rootBlockDevice.encrypted", "tags.Creator", "userData", "userDataBase64"]});

--- a/gen/nodejs/testdata/test_meta_properties/main.tf
+++ b/gen/nodejs/testdata/test_meta_properties/main.tf
@@ -1,0 +1,19 @@
+resource "aws_instance" "r1" {
+  timeouts {
+    "create" = "20m"
+    "update" = "5m"
+    "delete" = "1h"
+  }
+}
+
+resource "aws_instance" "r2" {
+  lifecycle {
+    ignore_changes = [ "*" ]
+  }
+}
+
+resource "aws_instance" "r3" {
+  lifecycle {
+    ignore_changes = [ "ami", "user_data", "tags.Creator", "network_interface.0.network_interface_id", "root_block_device.0.encrypted" ]
+  }
+}

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -331,6 +331,12 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 			v.Multi, v.Index = true, 0
 		}
 
+		// If this access refers to a non-counted resource but is a multi-access or an index, treat it as if it is
+		// a normal access.
+		if r.Count == nil && v.Multi {
+			v.Multi = false
+		}
+
 		// Handle multi-references (splats and indexes).
 		exprType = elemSch.Type().OutputOf()
 		if v.Multi && v.Index == -1 {

--- a/il/graph.go
+++ b/il/graph.go
@@ -637,6 +637,7 @@ func buildIgnoreChanges(tfIgnoreChanges []string, schemas Schemas) []string {
 			for k, v := range schemas.TFRes.Schema {
 				ignoreChanges = append(ignoreChanges, tfbridge.TerraformToPulumiName(k, v, false))
 			}
+			sort.Strings(ignoreChanges)
 			return ignoreChanges
 		}
 
@@ -682,6 +683,7 @@ func buildIgnoreChanges(tfIgnoreChanges []string, schemas Schemas) []string {
 			}
 		}
 	}
+	sort.Strings(ignoreChanges)
 	return ignoreChanges
 }
 

--- a/il/graph.go
+++ b/il/graph.go
@@ -628,7 +628,7 @@ func buildIgnoreChanges(tfIgnoreChanges []string, schemas Schemas) []string {
 		elements := strings.Split(entry, ".")
 
 		// If there is one element and that element is "*", ignore all of the top-level properties.
-		if len(elements) == 0 && elements[0] == "*" {
+		if len(elements) == 1 && elements[0] == "*" {
 			if schemas.TFRes == nil {
 				return []string{"*"}
 			}

--- a/il/graph_test.go
+++ b/il/graph_test.go
@@ -51,3 +51,85 @@ func TestLocalForwardReferences(t *testing.T) {
 	_, err := BuildGraph(tree, nil)
 	assert.NoError(t, err)
 }
+
+func TestMetaProperties(t *testing.T) {
+	conf, err := config.LoadDir("testdata/test_meta_properties")
+	if err != nil {
+		t.Fatalf("could not load config: %v", err)
+	}
+
+	g, err := BuildGraph(module.NewTree("main", conf), &BuildOptions{
+		AllowMissingProviders: true,
+		AllowMissingVariables: true,
+		AllowMissingComments:  true,
+	})
+	if err != nil {
+		t.Fatalf("could not build graph: %v", err)
+	}
+
+	r1, ok := g.Resources["aws_instance.r1"]
+	assert.True(t, ok)
+	assert.Equal(t, &BoundMapProperty{
+		Elements: map[string]BoundNode{
+			"create": &BoundLiteral{ExprType: TypeString, Value: "20m"},
+			"update": &BoundLiteral{ExprType: TypeString, Value: "5m"},
+			"delete": &BoundLiteral{ExprType: TypeString, Value: "1h"},
+		},
+	}, r1.Timeouts)
+
+	r2, ok := g.Resources["aws_instance.r2"]
+	assert.True(t, ok)
+	assert.Equal(t, []string{
+		"ami",
+		"arn",
+		"associatePublicIpAddress",
+		"availabilityZone",
+		"cpuCoreCount",
+		"cpuThreadsPerCore",
+		"creditSpecification",
+		"disableApiTermination",
+		"ebsBlockDevices",
+		"ebsOptimized",
+		"ephemeralBlockDevices",
+		"getPasswordData",
+		"hostId",
+		"iamInstanceProfile",
+		"instanceInitiatedShutdownBehavior",
+		"instanceState",
+		"instanceType",
+		"ipv6AddressCount",
+		"ipv6Addresses",
+		"keyName",
+		"monitoring",
+		"networkInterfaceId",
+		"networkInterfaces",
+		"passwordData",
+		"placementGroup",
+		"primaryNetworkInterfaceId",
+		"privateDns",
+		"privateIp",
+		"publicDns",
+		"publicIp",
+		"rootBlockDevice",
+		"securityGroups",
+		"sourceDestCheck",
+		"subnetId",
+		"tags",
+		"tenancy",
+		"userData",
+		"userDataBase64",
+		"volumeTags",
+		"vpcSecurityGroupIds",
+	}, r2.IgnoreChanges)
+
+	r3, ok := g.Resources["aws_instance.r3"]
+	assert.True(t, ok)
+	assert.Equal(t, []string{
+		"ami",
+		"networkInterfaces[0].networkInterfaceId",
+		"rootBlockDevice.encrypted",
+		"tags.Creator",
+		"userData",
+		"userDataBase64",
+	}, r3.IgnoreChanges)
+}

--- a/il/testdata/test_meta_properties/main.tf
+++ b/il/testdata/test_meta_properties/main.tf
@@ -1,0 +1,19 @@
+resource "aws_instance" "r1" {
+  timeouts {
+    "create" = "20m"
+    "update" = "5m"
+    "delete" = "1h"
+  }
+}
+
+resource "aws_instance" "r2" {
+  lifecycle {
+    ignore_changes = [ "*" ]
+  }
+}
+
+resource "aws_instance" "r3" {
+  lifecycle {
+    ignore_changes = [ "ami", "user_data", "tags.Creator", "network_interface.0.network_interface_id", "root_block_device.0.encrypted" ]
+  }
+}


### PR DESCRIPTION
- Custom timeouts are pulled verbatim from the `timeouts` property if it is present.
  This works because we use the same names (`create`, `update`, `delete`) for our
  own custom timeouts option.
- Any `ignore_changes` list is converted into an equivalent list of ignored properties.
  The most subtle aspect of this conversion is that Terraform accepts a key prefix
  rather than a full key; we support this by expanding the last element of the key
  by matching subproperties at the final level by prefix as well.