### PR TITLE
Add support for generating conditional resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a command line option, `-record-locations`, that indicates that each resource, data source, etc. in the
   generated code should be annotated with the location of its original definition in the source Terraform config.
 - Fix code generation for `replace` when the pattern is a regex.
+- Generate resources that are instantiated at most exactly once using `if` statements rather than `for` loops.
 
 ## v0.5.1 (Released August 14, 2019)
 

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -191,3 +191,22 @@ func TestOrdering(t *testing.T) {
 	expectedText := readFile(t, "testdata/test_ordering/index.ts")
 	assert.Equal(t, expectedText, b.String())
 }
+
+func TestConditionals(t *testing.T) {
+	conf := loadConfig(t, "testdata/test_conditionals")
+	g, err := il.BuildGraph(module.NewTree("main", conf), &il.BuildOptions{
+		AllowMissingProviders: true,
+	})
+	if err != nil {
+		t.Fatalf("could not build graph: %v", err)
+	}
+
+	var b bytes.Buffer
+	lang, err := New("main", "1.0.0", true, &b)
+	assert.NoError(t, err)
+	err = gen.Generate([]*il.Graph{g}, lang)
+	assert.NoError(t, err)
+
+	expectedText := readFile(t, "testdata/test_conditionals/index.ts")
+	assert.Equal(t, expectedText, b.String())
+}

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -490,6 +490,14 @@ func (g *generator) GenVariableAccess(w io.Writer, n *il.BoundVariableAccess) {
 	case *config.ResourceVariable:
 		// We only generate up to the "output" part of the path here: the apply transform will take care of the rest.
 		g.Fgen(w, g.variableName(n))
+
+		// If this references a conditional resource, pretend it is not a multi access and generate an assertion
+		// expression.
+		if r, ok := n.ILNode.(*il.ResourceNode); ok && g.isConditionalResource(r) {
+			v.Multi = false
+			g.Fgen(w, "!")
+		}
+
 		if v.Multi && v.Index != -1 {
 			g.Fgenf(w, "[%d]", v.Index)
 		}

--- a/gen/nodejs/testdata/test_conditionals/index.ts
+++ b/gen/nodejs/testdata/test_conditionals/index.ts
@@ -1,0 +1,63 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// Accept the AWS region as input.
+const awsRegion = config.get("awsRegion") || "us-west-2";
+const createSg = config.getBoolean("createSg") || false;
+
+const inUsEast1 = (awsRegion === "us-east-1");
+// If we are in us-east-1, create an ec2 instance
+let web: aws.ec2.Instance | undefined;
+if (inUsEast1) {
+    web = new aws.ec2.Instance("web", {
+        ami: "some-ami",
+        instanceType: "t2.micro",
+        tags: {
+            Name: "HelloWorld",
+        },
+    });
+}
+// If we are in us-east-2, create a different ec2 instance
+const createWeb2 = ((awsRegion === "us-east-2") ? 1 : 0);
+let web2: aws.ec2.Instance | undefined;
+if (!!(createWeb2)) {
+    web2 = new aws.ec2.Instance("web2", {
+        ami: "some-other-ami",
+        instanceType: "t2.micro",
+        tags: {
+            Name: `instance-${(createWeb2 % 2)}`,
+        },
+    });
+}
+// Optionally create a security group and attach some rules.
+let defaultSecurityGroup: aws.ec2.SecurityGroup | undefined;
+if (createSg) {
+    defaultSecurityGroup = new aws.ec2.SecurityGroup("default", {
+        description: "Default security group",
+    });
+}
+// outbound internet access
+let egress: aws.ec2.SecurityGroupRule | undefined;
+if (createSg) {
+    egress = new aws.ec2.SecurityGroupRule("egress", {
+        cidrBlocks: ["0.0.0.0/0"],
+        fromPort: 0,
+        protocol: "-1",
+        securityGroupId: defaultSecurityGroup!.id,
+        toPort: 0,
+        type: "ingress",
+    });
+}
+// SSH access from anywhere
+let ingress: aws.ec2.SecurityGroupRule | undefined;
+if (createSg) {
+    ingress = new aws.ec2.SecurityGroupRule("ingress", {
+        cidrBlocks: ["0.0.0.0/0"],
+        fromPort: 22,
+        protocol: "tcp",
+        securityGroupId: defaultSecurityGroup!.id,
+        toPort: 22,
+        type: "ingress",
+    });
+}

--- a/gen/nodejs/testdata/test_conditionals/main.tf
+++ b/gen/nodejs/testdata/test_conditionals/main.tf
@@ -1,0 +1,70 @@
+variable "create_sg" {
+  default = false
+}
+
+# Accept the AWS region as input.
+variable "aws_region" {
+  # Default to us-west-2
+  default = "us-west-2"
+}
+
+locals {
+  in_us_east_1 = "${var.aws_region == "us-east-1"}"
+}
+
+# Optionally create a security group and attach some rules.
+resource "aws_security_group" "default" {
+  count = "${var.create_sg ? 1 : 0}"
+
+  description = "Default security group"
+}
+
+# SSH access from anywhere
+resource "aws_security_group_rule" "ingress" {
+  count = "${var.create_sg ? 1 : 0}"
+
+  type = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+# outbound internet access
+resource "aws_security_group_rule" "egress" {
+  count = "${var.create_sg ? 1 : 0}"
+
+  type = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+# If we are in us-east-1, create an ec2 instance
+resource "aws_instance" "web" {
+  count = "${local.in_us_east_1}"
+
+  ami           = "some-ami"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}
+
+# If we are in us-east-2, create a different ec2 instance
+resource "aws_instance" "web2" {
+  count = "${var.aws_region == "us-east-2" ? 1 : 0}"
+
+  ami = "some-other-ami"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "instance-${count.index % 2}"
+  }
+}

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -29,7 +29,18 @@ func (b *propertyBinder) bindArithmetic(n *ast.Arithmetic) (BoundExpr, error) {
 		return nil, err
 	}
 
-	return &BoundArithmetic{HILNode: n, Exprs: exprs}, nil
+	var typ Type
+	switch n.Op {
+	case ast.ArithmeticOpLogicalAnd, ast.ArithmeticOpLogicalOr,
+		ast.ArithmeticOpEqual, ast.ArithmeticOpNotEqual,
+		ast.ArithmeticOpLessThan, ast.ArithmeticOpLessThanOrEqual,
+		ast.ArithmeticOpGreaterThan, ast.ArithmeticOpGreaterThanOrEqual:
+		typ = TypeBool
+	default:
+		typ = TypeNumber
+	}
+
+	return &BoundArithmetic{HILNode: n, Exprs: exprs, ExprType: typ}, nil
 }
 
 // bindCall binds an HIL call expression. This involves binding the call's arguments, then using the name of the called

--- a/il/boundTree.go
+++ b/il/boundTree.go
@@ -168,11 +168,13 @@ type BoundArithmetic struct {
 	NodeComments *Comments
 	// Exprs is the bound list of the arithmetic expression's operands.
 	Exprs []BoundExpr
+	// ExprType is the type of the arithmetic expression.
+	ExprType Type
 }
 
-// Type returns the type of the arithmetic expression, which is always TypeNumber.
+// Type returns the type of the arithmetic expression.
 func (n *BoundArithmetic) Type() Type {
-	return TypeNumber
+	return n.ExprType
 }
 
 // Comments returns the comments attached to this node, if any.

--- a/il/rewriters.go
+++ b/il/rewriters.go
@@ -373,7 +373,7 @@ func SimplifyBooleanExpressions(expr BoundExpr) BoundExpr {
 
 			// Otherwise, we can simplify to the condition expression itself if the true leg resolves to the literal
 			// "true" and the false leg resolves to the literal "false".
-			if trueVal == true && falseVal == false {
+			if trueVal && !falseVal {
 				return condExpr
 			}
 		}


### PR DESCRIPTION
Conditionally-instantiated resources are now generated using `if`
statements rather than `for` loops. For most resources, the generated
code is as simple as:

```
let foo: Foo | undefined;
if (condition) {
    foo = new Foo(...);
}
```

For resources with properties that reference the condition variable,
the code generation is a little bit more complicated. In this case, we
assign the result of the condition to a local so that the resource has
something to reference:

```
const createFoo = condition;
let foo: Foo | undefined;
if (createFoo) {
    foo = new Foo(...);
}
```

Fixes #123.