### PR TITLE
Remove the usage of module.Tree from il.Graph.

### DIFF
--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -268,7 +268,7 @@ func (g *generator) computeProperty(prop il.BoundNode, indent bool, count string
 
 // isRoot returns true if we are generating code for the root module.
 func (g *generator) isRoot() bool {
-	return len(g.module.Tree.Path()) == 0
+	return g.module.IsRoot
 }
 
 // genLeadingComment generates a leading comment into the output.
@@ -301,8 +301,8 @@ func (g *generator) genTrailingComment(w io.Writer, comments *il.Comments) {
 func (g *generator) GeneratePreamble(modules []*il.Graph) error {
 	// Find the root module and stash its path.
 	for _, m := range modules {
-		if len(m.Tree.Path()) == 0 {
-			g.rootPath = m.Tree.Config().Dir
+		if m.IsRoot {
+			g.rootPath = m.Path
 			break
 		}
 	}
@@ -383,7 +383,7 @@ func (g *generator) BeginModule(m *il.Graph) error {
 	g.module = m
 	if !g.isRoot() {
 		g.Printf("const new_mod_%s = function(mod_name: string, mod_args: pulumi.Inputs) {\n",
-			cleanName(m.Tree.Name()))
+			cleanName(m.Name))
 		g.Indent += "    "
 
 		// Discover the set of input variables that may have unknown values. This is the complete set of inputs minus
@@ -563,7 +563,7 @@ func (g *generator) GenerateProvider(p *il.ProviderNode) error {
 	}
 
 	var resName string
-	if len(g.module.Tree.Path()) == 0 {
+	if g.isRoot() {
 		resName = fmt.Sprintf("\"%s\"", p.Config.Alias)
 	} else {
 		resName = fmt.Sprintf("`${mod_name}_%s`", p.Config.Alias)

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -76,7 +76,7 @@ func TestLowerToLiteral(t *testing.T) {
 
 	g := &generator{
 		rootPath: ".",
-		module:   &il.Graph{Tree: module.NewTree("foo", &config.Config{Dir: "./foo/bar"})},
+		module:   &il.Graph{IsRoot: true, Path: "./foo/bar"},
 	}
 	g.Emitter = gen.NewEmitter(nil, g)
 

--- a/gen/nodejs/lower.go
+++ b/gen/nodejs/lower.go
@@ -38,7 +38,7 @@ func (g *generator) lowerToLiterals(prop il.BoundNode) (il.BoundNode, error) {
 
 		switch pv.Type {
 		case config.PathValueModule:
-			path := g.module.Tree.Config().Dir
+			path := g.module.Path
 
 			// Attempt to make this path relative to that of the root module.
 			rel, err := filepath.Rel(g.rootPath, path)

--- a/gen/python/generator.go
+++ b/gen/python/generator.go
@@ -89,7 +89,7 @@ func (g *generator) GeneratePreamble(modules []*il.Graph) error {
 }
 
 func (g *generator) BeginModule(mod *il.Graph) error {
-	if len(mod.Tree.Path()) != 0 {
+	if !mod.IsRoot {
 		return errors.New("NYI: Python Modules")
 	}
 	return nil

--- a/il/graph.go
+++ b/il/graph.go
@@ -36,8 +36,12 @@ import (
 
 // A Graph is the analyzed form of the configuration for a single Terraform module.
 type Graph struct {
-	// Tree is the module's entry in the module tree. The tree is used e.g. to determine the module's name.
-	Tree *module.Tree
+	// Name is the name of the module. May be the empty string when IsRoot is true.
+	Name string
+	// IsRoot is true if this is the root module.
+	IsRoot bool
+	// Path is the path to this module's directory.
+	Path string
 	// Modules maps from module name to module node for this module's module instantiations. This map is used to
 	// bind a module variable access in an interpolation to the corresponding module node.
 	Modules map[string]*ModuleNode
@@ -936,7 +940,9 @@ func BuildGraph(tree *module.Tree, opts *BuildOptions) (*Graph, error) {
 
 	// Put the graph together
 	return &Graph{
-		Tree:      tree,
+		Name:      tree.Name(),
+		IsRoot:    len(tree.Path()) == 0,
+		Path:      conf.Dir,
 		Modules:   b.modules,
 		Providers: b.providers,
 		Resources: b.resources,


### PR DESCRIPTION
Just what it says on the tin. This is the first step in abstracting away
the specifics of the Terraform config used to build a graph.