### PR TITLE
Remove HIL nodes from bound expressions.

### DIFF
--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/hil/ast"
 	"github.com/hashicorp/terraform/config"
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -195,7 +194,7 @@ func boundRef(v string, typ il.Type, node il.Node) *il.BoundVariableAccess {
 
 func applyArgRef(arg il.BoundExpr, index int) *il.BoundCall {
 	return &il.BoundCall{
-		HILNode:  &ast.Call{Func: "__applyArg"},
+		Func:     "__applyArg",
 		ExprType: arg.Type().ElementType(),
 		Args:     []il.BoundExpr{&il.BoundLiteral{ExprType: il.TypeNumber, Value: index}},
 	}

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -342,7 +342,7 @@ func (g *generator) GeneratePreamble(modules []*il.Graph) error {
 	findOptionals := func(n il.BoundNode) (il.BoundNode, error) {
 		switch n := n.(type) {
 		case *il.BoundCall:
-			switch n.HILNode.Func {
+			switch n.Func {
 			case "file":
 				if !g.importNames["fs"] {
 					imports = append(imports, `import * as fs from "fs";`)

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -51,7 +51,6 @@ func TestLowerToLiteral(t *testing.T) {
 	prop := &il.BoundMapProperty{
 		Elements: map[string]il.BoundNode{
 			"key": &il.BoundOutput{
-				HILNode: nil,
 				Exprs: []il.BoundExpr{
 					&il.BoundLiteral{
 						ExprType: il.TypeString,

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -34,7 +34,7 @@ import (
 // GenArithmetic generates code for the given arithmetic expression.
 func (g *generator) GenArithmetic(w io.Writer, n *il.BoundArithmetic) {
 	op := ""
-	switch n.HILNode.Op {
+	switch n.Op {
 	case ast.ArithmeticOpAdd:
 		op = "+"
 	case ast.ArithmeticOpSub:
@@ -220,7 +220,7 @@ func (g *generator) genCoercion(w io.Writer, n il.BoundExpr, toType il.Type) {
 
 // GenCall generates code for a call expression.
 func (g *generator) GenCall(w io.Writer, n *il.BoundCall) {
-	switch n.HILNode.Func {
+	switch n.Func {
 	case il.IntrinsicApply:
 		g.genApply(w, n)
 	case il.IntrinsicApplyArg:
@@ -375,7 +375,7 @@ func (g *generator) GenCall(w io.Writer, n *il.BoundCall) {
 		g.Fgenf(w, "((keys, values) => Object.assign.apply({}, keys.map((k: any, i: number) => ({[k]: values[i]}))))(%v, %v)",
 			n.Args[0], n.Args[1])
 	default:
-		g.Fgenf(w, "(() => { throw \"NYI: call to %v\"; })()", n.HILNode.Func)
+		g.Fgenf(w, "(() => { throw \"NYI: call to %v\"; })()", n.Func)
 	}
 }
 

--- a/gen/nodejs/intrinsics.go
+++ b/gen/nodejs/intrinsics.go
@@ -15,7 +15,6 @@
 package nodejs
 
 import (
-	"github.com/hashicorp/hil/ast"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pulumi/tf2pulumi/il"
@@ -32,7 +31,7 @@ const (
 // data source function with the given input properties.
 func newDataSourceCall(functionName string, inputs il.BoundNode, optionsBag string) *il.BoundCall {
 	return &il.BoundCall{
-		HILNode:  &ast.Call{Func: intrinsicDataSource},
+		Func:     intrinsicDataSource,
 		ExprType: il.TypeMap,
 		Args: []il.BoundExpr{
 			&il.BoundLiteral{
@@ -54,7 +53,7 @@ func newDataSourceCall(functionName string, inputs il.BoundNode, optionsBag stri
 // parseDataSourceCall extracts the name of the data source function and the input properties for its invocation from
 // a call to the data source intrinsic.
 func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode, optionsBag string) {
-	contract.Assert(c.HILNode.Func == intrinsicDataSource)
+	contract.Assert(c.Func == intrinsicDataSource)
 	function = c.Args[0].(*il.BoundLiteral).Value.(string)
 	inputs = c.Args[1].(*il.BoundPropertyValue).Value
 	optionsBag = c.Args[2].(*il.BoundLiteral).Value.(string)
@@ -65,7 +64,7 @@ func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode,
 // pulumi.interpolate function.
 func newInterpolateCall(args []il.BoundExpr) *il.BoundCall {
 	return &il.BoundCall{
-		HILNode:  &ast.Call{Func: intrinsicInterpolate},
+		Func:     intrinsicInterpolate,
 		ExprType: il.TypeString.OutputOf(),
 		Args:     args,
 	}

--- a/gen/nodejs/intrinsics_test.go
+++ b/gen/nodejs/intrinsics_test.go
@@ -27,7 +27,7 @@ func TestIntrinsicDataSource(t *testing.T) {
 	optionsBag := ", {}"
 
 	c := newDataSourceCall(function, inputs, optionsBag)
-	assert.Equal(t, intrinsicDataSource, c.HILNode.Func)
+	assert.Equal(t, intrinsicDataSource, c.Func)
 	assert.Equal(t, il.TypeMap, c.ExprType)
 	assert.Equal(t, 3, len(c.Args))
 

--- a/gen/nodejs/lower.go
+++ b/gen/nodejs/lower.go
@@ -81,7 +81,7 @@ func (g *generator) parseProxyApply(args []*il.BoundVariableAccess, then il.Boun
 	}
 
 	thenCall, ok := then.(*il.BoundCall)
-	if !ok || thenCall.HILNode.Func != il.IntrinsicApplyArg {
+	if !ok || thenCall.Func != il.IntrinsicApplyArg {
 		return nil, false
 	}
 
@@ -103,7 +103,7 @@ func (g *generator) parseProxyApply(args []*il.BoundVariableAccess, then il.Boun
 func hasApplyArgDescendant(expr il.BoundExpr) bool {
 	has := false
 	_, err := il.VisitBoundNode(expr, il.IdentityVisitor, func(n il.BoundNode) (il.BoundNode, error) {
-		if c, ok := n.(*il.BoundCall); ok && c.HILNode.Func == il.IntrinsicApplyArg {
+		if c, ok := n.(*il.BoundCall); ok && c.Func == il.IntrinsicApplyArg {
 			has = true
 		}
 		return n, nil
@@ -129,7 +129,7 @@ func (g *generator) parseInterpolate(args []*il.BoundVariableAccess, then il.Bou
 	for i, expr := range thenOutput.Exprs {
 		call, isCall := expr.(*il.BoundCall)
 		switch {
-		case isCall && call.HILNode.Func == il.IntrinsicApplyArg:
+		case isCall && call.Func == il.IntrinsicApplyArg:
 			v := args[il.ParseApplyArgCall(call)]
 			if !g.canLiftVariableAccess(v) {
 				return nil, false
@@ -158,7 +158,7 @@ func (g *generator) lowerProxyApplies(prop il.BoundNode) (il.BoundNode, error) {
 	rewriter := func(n il.BoundNode) (il.BoundNode, error) {
 		// Ignore the node if it is not a call to the apply intrinsic.
 		apply, ok := n.(*il.BoundCall)
-		if !ok || apply.HILNode.Func != il.IntrinsicApply {
+		if !ok || apply.Func != il.IntrinsicApply {
 			return n, nil
 		}
 

--- a/gen/python/hil.go
+++ b/gen/python/hil.go
@@ -44,7 +44,7 @@ func (g *generator) GenArithmetic(w io.Writer, v *il.BoundArithmetic) {
 }
 
 func (g *generator) GenCall(w io.Writer, v *il.BoundCall) {
-	switch v.HILNode.Func {
+	switch v.Func {
 	case intrinsicDataSource:
 		g.genDataSourceCall(w, v)
 	case intrinsicResource:

--- a/gen/python/intrinsics.go
+++ b/gen/python/intrinsics.go
@@ -15,8 +15,6 @@
 package python
 
 import (
-	"github.com/hashicorp/hil/ast"
-
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/tf2pulumi/il"
 )
@@ -28,7 +26,7 @@ const (
 
 func newResourceCall(resourceType, resourceName string, inputs *il.BoundMapProperty) *il.BoundCall {
 	return &il.BoundCall{
-		HILNode:  &ast.Call{Func: intrinsicResource},
+		Func:     intrinsicResource,
 		ExprType: il.TypeMap,
 		Args: []il.BoundExpr{
 			&il.BoundLiteral{
@@ -49,7 +47,7 @@ func newResourceCall(resourceType, resourceName string, inputs *il.BoundMapPrope
 
 func newDataSourceCall(functionName string, inputs *il.BoundMapProperty) *il.BoundCall {
 	return &il.BoundCall{
-		HILNode:  &ast.Call{Func: intrinsicDataSource},
+		Func:     intrinsicDataSource,
 		ExprType: il.TypeMap,
 		Args: []il.BoundExpr{
 			&il.BoundLiteral{
@@ -67,14 +65,14 @@ func newDataSourceCall(functionName string, inputs *il.BoundMapProperty) *il.Bou
 // parseDataSourceCall extracts the name of the data source function and the input properties for its invocation from
 // a call to the data source intrinsic.
 func parseDataSourceCall(c *il.BoundCall) (function string, inputs *il.BoundMapProperty) {
-	contract.Assert(c.HILNode.Func == intrinsicDataSource)
+	contract.Assert(c.Func == intrinsicDataSource)
 	return c.Args[0].(*il.BoundLiteral).Value.(string), c.Args[1].(*il.BoundPropertyValue).Value.(*il.BoundMapProperty)
 }
 
 // parseResourceCall extracts the type of the resource, the name of the resource, and the resource's input properties
 // from a call to the resource intrinsic.
 func parseResourceCall(c *il.BoundCall) (resource, name string, inputs *il.BoundMapProperty) {
-	contract.Assert(c.HILNode.Func == intrinsicResource)
+	contract.Assert(c.Func == intrinsicResource)
 	return c.Args[0].(*il.BoundLiteral).Value.(string),
 		c.Args[1].(*il.BoundLiteral).Value.(string),
 		c.Args[2].(*il.BoundPropertyValue).Value.(*il.BoundMapProperty)

--- a/gen/python/rewriters.go
+++ b/gen/python/rewriters.go
@@ -21,12 +21,12 @@ import (
 type trivialApplyRewriter struct{}
 
 func (t trivialApplyRewriter) rewriteNode(n il.BoundNode) (il.BoundNode, error) {
-	if e, ok := n.(*il.BoundCall); ok && e.HILNode.Func == il.IntrinsicApply {
+	if e, ok := n.(*il.BoundCall); ok && e.Func == il.IntrinsicApply {
 		args, access := il.ParseApplyCall(e)
 		if len(args) != 1 {
 			return n, nil
 		}
-		if applyArg, ok := access.(*il.BoundCall); ok && applyArg.HILNode.Func == il.IntrinsicApplyArg {
+		if applyArg, ok := access.(*il.BoundCall); ok && applyArg.Func == il.IntrinsicApplyArg {
 			index := il.ParseApplyArgCall(applyArg)
 			if index != 0 {
 				// Not sure what this is - leave it alone.

--- a/il/binder_hil.go
+++ b/il/binder_hil.go
@@ -40,7 +40,7 @@ func (b *propertyBinder) bindArithmetic(n *ast.Arithmetic) (BoundExpr, error) {
 		typ = TypeNumber
 	}
 
-	return &BoundArithmetic{HILNode: n, Exprs: exprs, ExprType: typ}, nil
+	return &BoundArithmetic{Op: n.Op, Exprs: exprs, ExprType: typ}, nil
 }
 
 // bindCall binds an HIL call expression. This involves binding the call's arguments, then using the name of the called
@@ -117,7 +117,7 @@ func (b *propertyBinder) bindCall(n *ast.Call) (BoundExpr, error) {
 		err = errors.Errorf("NYI: call to %s", n.Func)
 	}
 
-	boundCall := &BoundCall{HILNode: n, ExprType: exprType, Args: args}
+	boundCall := &BoundCall{Func: n.Func, ExprType: exprType, Args: args}
 	if err != nil {
 		return &BoundError{Value: boundCall, NodeType: exprType, Error: err}, nil
 	}
@@ -147,7 +147,6 @@ func (b *propertyBinder) bindConditional(n *ast.Conditional) (BoundExpr, error) 
 	}
 
 	return &BoundConditional{
-		HILNode:   n,
 		ExprType:  exprType,
 		CondExpr:  condExpr,
 		TrueExpr:  trueExpr,
@@ -175,7 +174,6 @@ func (b *propertyBinder) bindIndex(n *ast.Index) (BoundExpr, error) {
 	}
 
 	return &BoundIndex{
-		HILNode:    n,
 		ExprType:   exprType,
 		TargetExpr: boundTarget,
 		KeyExpr:    boundKey,
@@ -214,7 +212,7 @@ func (b *propertyBinder) bindOutput(n *ast.Output) (BoundExpr, error) {
 		return exprs[0], nil
 	}
 
-	return &BoundOutput{HILNode: n, Exprs: exprs}, nil
+	return &BoundOutput{Exprs: exprs}, nil
 }
 
 // bindVariableAccess binds an HIL variable access expression. This involves first interpreting the variable name as a
@@ -246,7 +244,6 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		if !ok {
 			if b.builder.allowMissingVariables {
 				return &BoundVariableAccess{
-					HILNode:  n,
 					ExprType: TypeUnknown,
 					TFVar:    v,
 				}, nil
@@ -267,7 +264,6 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		if !ok {
 			if b.builder.allowMissingVariables {
 				return &BoundVariableAccess{
-					HILNode:  n,
 					ExprType: TypeUnknown.OutputOf(),
 					TFVar:    v,
 				}, nil
@@ -291,7 +287,6 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		if !ok {
 			if b.builder.allowMissingVariables {
 				return &BoundVariableAccess{
-					HILNode:  n,
 					Elements: elements,
 					ExprType: TypeUnknown.OutputOf(),
 					TFVar:    v,
@@ -364,7 +359,6 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 		if !ok {
 			if b.builder.allowMissingVariables {
 				return &BoundVariableAccess{
-					HILNode:  n,
 					ExprType: TypeString,
 					TFVar:    v,
 				}, nil
@@ -384,7 +378,6 @@ func (b *propertyBinder) bindVariableAccess(n *ast.VariableAccess) (BoundExpr, e
 	}
 
 	return &BoundVariableAccess{
-		HILNode:  n,
 		Elements: elements,
 		Schemas:  sch,
 		ExprType: exprType,

--- a/il/intrinsics.go
+++ b/il/intrinsics.go
@@ -15,7 +15,6 @@
 package il
 
 import (
-	"github.com/hashicorp/hil/ast"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
@@ -43,7 +42,7 @@ func NewApplyCall(args []*BoundVariableAccess, then BoundExpr) *BoundCall {
 	exprs[len(exprs)-1] = then
 
 	return &BoundCall{
-		HILNode:  &ast.Call{Func: IntrinsicApply},
+		Func:     IntrinsicApply,
 		ExprType: then.Type().OutputOf(),
 		Args:     exprs,
 	}
@@ -51,7 +50,7 @@ func NewApplyCall(args []*BoundVariableAccess, then BoundExpr) *BoundCall {
 
 // ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.
 func ParseApplyCall(c *BoundCall) (applyArgs []*BoundVariableAccess, then BoundExpr) {
-	contract.Assert(c.HILNode.Func == IntrinsicApply)
+	contract.Assert(c.Func == IntrinsicApply)
 
 	args := make([]*BoundVariableAccess, len(c.Args)-1)
 	for i, a := range c.Args[:len(args)] {
@@ -65,7 +64,7 @@ func ParseApplyCall(c *BoundCall) (applyArgs []*BoundVariableAccess, then BoundE
 func NewApplyArgCall(argIndex int, argType Type) *BoundCall {
 	contract.Assert(!argType.IsOutput())
 	return &BoundCall{
-		HILNode:  &ast.Call{Func: IntrinsicApplyArg},
+		Func:     IntrinsicApplyArg,
 		ExprType: argType,
 		Args:     []BoundExpr{&BoundLiteral{ExprType: TypeNumber, Value: argIndex}},
 	}
@@ -73,14 +72,14 @@ func NewApplyArgCall(argIndex int, argType Type) *BoundCall {
 
 // ParseapplyArgCall extracts the argument index from a call to the apply arg intrinsic.
 func ParseApplyArgCall(c *BoundCall) int {
-	contract.Assert(c.HILNode.Func == IntrinsicApplyArg)
+	contract.Assert(c.Func == IntrinsicApplyArg)
 	return c.Args[0].(*BoundLiteral).Value.(int)
 }
 
 // NewArchiveCall creates a call to IntrinsicArchive.
 func NewArchiveCall(arg BoundExpr) *BoundCall {
 	return &BoundCall{
-		HILNode:  &ast.Call{Func: IntrinsicArchive},
+		Func:     IntrinsicArchive,
 		ExprType: TypeUnknown,
 		Args:     []BoundExpr{arg},
 	}
@@ -88,14 +87,14 @@ func NewArchiveCall(arg BoundExpr) *BoundCall {
 
 // ParseArchiveCall extracts the single argument expression from a call to the archive intrinsic.
 func ParseArchiveCall(c *BoundCall) (arg BoundExpr) {
-	contract.Assert(c.HILNode.Func == IntrinsicArchive)
+	contract.Assert(c.Func == IntrinsicArchive)
 	return c.Args[0]
 }
 
 // NewAssetCall creates a call to IntrinsicArchive.
 func NewAssetCall(arg BoundExpr) *BoundCall {
 	return &BoundCall{
-		HILNode:  &ast.Call{Func: IntrinsicAsset},
+		Func:     IntrinsicAsset,
 		ExprType: TypeUnknown,
 		Args:     []BoundExpr{arg},
 	}
@@ -103,7 +102,7 @@ func NewAssetCall(arg BoundExpr) *BoundCall {
 
 // ParseAssetCall extracts the single argument expression from a call to the asset intrinsic.
 func ParseAssetCall(c *BoundCall) (arg BoundExpr) {
-	contract.Assert(c.HILNode.Func == IntrinsicAsset)
+	contract.Assert(c.Func == IntrinsicAsset)
 	return c.Args[0]
 }
 
@@ -111,7 +110,7 @@ func ParseAssetCall(c *BoundCall) (arg BoundExpr) {
 // another.
 func NewCoerceCall(value BoundExpr, toType Type) *BoundCall {
 	return &BoundCall{
-		HILNode:  &ast.Call{Func: IntrinsicCoerce},
+		Func:     IntrinsicCoerce,
 		ExprType: toType,
 		Args:     []BoundExpr{value},
 	}
@@ -120,11 +119,11 @@ func NewCoerceCall(value BoundExpr, toType Type) *BoundCall {
 // ParseCoerceCall extracts the value being coerced and the type to which it is being coerced from a call to the coerce
 // intrinsic.
 func ParseCoerceCall(c *BoundCall) (value BoundExpr, toType Type) {
-	contract.Assert(c.HILNode.Func == IntrinsicCoerce)
+	contract.Assert(c.Func == IntrinsicCoerce)
 	return c.Args[0], c.ExprType
 }
 
 // NewGetStackCall creates a call to IntrinsicGetStack.
 func NewGetStackCall() *BoundCall {
-	return &BoundCall{HILNode: &ast.Call{Func: IntrinsicGetStack}, ExprType: TypeString}
+	return &BoundCall{Func: IntrinsicGetStack, ExprType: TypeString}
 }

--- a/il/intrinsics_test.go
+++ b/il/intrinsics_test.go
@@ -29,7 +29,7 @@ func TestIntrinsicApply(t *testing.T) {
 	then := &BoundLiteral{}
 
 	c := NewApplyCall(args, then)
-	assert.Equal(t, IntrinsicApply, c.HILNode.Func)
+	assert.Equal(t, IntrinsicApply, c.Func)
 	assert.Equal(t, then.Type().OutputOf(), c.ExprType)
 	assert.Equal(t, len(args)+1, len(c.Args))
 
@@ -42,7 +42,7 @@ func TestIntrinsicApplyArg(t *testing.T) {
 	idx, typ := 3, TypeString
 
 	c := NewApplyArgCall(idx, typ)
-	assert.Equal(t, IntrinsicApplyArg, c.HILNode.Func)
+	assert.Equal(t, IntrinsicApplyArg, c.Func)
 	assert.Equal(t, typ, c.Type())
 	assert.Equal(t, 1, len(c.Args))
 
@@ -53,7 +53,7 @@ func TestIntrinsicArchive(t *testing.T) {
 	arg := &BoundLiteral{}
 
 	c := NewArchiveCall(arg)
-	assert.Equal(t, IntrinsicArchive, c.HILNode.Func)
+	assert.Equal(t, IntrinsicArchive, c.Func)
 	assert.Equal(t, TypeUnknown, c.Type())
 	assert.Equal(t, 1, len(c.Args))
 
@@ -64,7 +64,7 @@ func TestIntrinsicAsset(t *testing.T) {
 	arg := &BoundLiteral{}
 
 	c := NewAssetCall(arg)
-	assert.Equal(t, IntrinsicAsset, c.HILNode.Func)
+	assert.Equal(t, IntrinsicAsset, c.Func)
 	assert.Equal(t, TypeUnknown, c.Type())
 	assert.Equal(t, 1, len(c.Args))
 
@@ -75,7 +75,7 @@ func TestIntrinsicCoerce(t *testing.T) {
 	value, toType := &BoundLiteral{}, TypeNumber
 
 	c := NewCoerceCall(value, toType)
-	assert.Equal(t, IntrinsicCoerce, c.HILNode.Func)
+	assert.Equal(t, IntrinsicCoerce, c.Func)
 	assert.Equal(t, toType, c.Type())
 	assert.Equal(t, 1, len(c.Args))
 
@@ -86,7 +86,7 @@ func TestIntrinsicCoerce(t *testing.T) {
 
 func TestIntrinsicGetStack(t *testing.T) {
 	c := NewGetStackCall()
-	assert.Equal(t, IntrinsicGetStack, c.HILNode.Func)
+	assert.Equal(t, IntrinsicGetStack, c.Func)
 	assert.Equal(t, TypeString, c.Type())
 	assert.Equal(t, 0, len(c.Args))
 }


### PR DESCRIPTION
Copy the information we need from these nodes onto the expression nodes
themselves. This eliminates the need for downstream code to understand
HIL syntax nodes.