### PR TITLE
Remove the usage of raw TF11 config in IL.

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/hashicorp/terraform/command"
-	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/svchost"
 	"github.com/hashicorp/terraform/svchost/auth"
@@ -117,7 +116,7 @@ func Convert(opts Options) error {
 		filterAutoNames := opts.ResourceNameProperty == ""
 		for _, g := range gs {
 			for _, r := range g.Resources {
-				if r.Config.Mode == config.ManagedResourceMode {
+				if !r.IsDataSource {
 					il.FilterProperties(r, func(key string, _ il.BoundNode) bool {
 						if filterAutoNames {
 							sch := r.Schemas().PropertySchemas(key).Pulumi

--- a/gen/nodejs/archive.go
+++ b/gen/nodejs/archive.go
@@ -27,7 +27,7 @@ import (
 // computeArchiveInputs computes the inputs for a call to the pulumi.AssetArchive constructor based on the values
 // present in the given resource's bound input properties.
 func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
-	contract.Require(r.Provider.Config.Name == "archive", "r")
+	contract.Require(r.Provider.Name == "archive", "r")
 
 	buf := &bytes.Buffer{}
 	buf.WriteString("{\n")
@@ -48,7 +48,7 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 	} else if sourceContent, ok := r.Properties.Elements["source_content"]; ok {
 		filename, ok := r.Properties.Elements["source_filename"]
 		if !ok {
-			return "", errors.Errorf("missing source_filename property in archive %s", r.Config.Id())
+			return "", errors.Errorf("missing source_filename property in archive %s", r.Name)
 		}
 
 		path, _, err := g.computeProperty(filename, indent, count)
@@ -64,22 +64,22 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 	} else if source, ok := r.Properties.Elements["source"]; ok {
 		list, ok := source.(*il.BoundListProperty)
 		if !ok {
-			return "", errors.Errorf("unexpected type for source in archive %s", r.Config.Id())
+			return "", errors.Errorf("unexpected type for source in archive %s", r.Name)
 		}
 
 		for _, e := range list.Elements {
 			m, ok := e.(*il.BoundMapProperty)
 			if !ok {
-				return "", errors.Errorf("unexpected type for source in archive %s", r.Config.Id())
+				return "", errors.Errorf("unexpected type for source in archive %s", r.Name)
 			}
 
 			sourceContent, ok := m.Elements["content"]
 			if !ok {
-				return "", errors.Errorf("missing property \"content\" in archive %s", r.Config.Id())
+				return "", errors.Errorf("missing property \"content\" in archive %s", r.Name)
 			}
 			sourceFilename, ok := m.Elements["filename"]
 			if !ok {
-				return "", errors.Errorf("missing property \"filename\" in archive %s", r.Config.Id())
+				return "", errors.Errorf("missing property \"filename\" in archive %s", r.Name)
 			}
 
 			content, _, err := g.computeProperty(sourceContent, indent, count)
@@ -100,7 +100,7 @@ func (g *generator) computeArchiveInputs(r *il.ResourceNode, indent bool, count 
 
 // generateArchive generates a call to the pulumi.AssetArchive constructor for the given archive resource.
 func (g *generator) generateArchive(r *il.ResourceNode) error {
-	contract.Require(r.Provider.Config.Name == "archive", "r")
+	contract.Require(r.Provider.Name == "archive", "r")
 
 	// TODO: explicit dependencies (or any dependencies at all, really)
 

--- a/gen/nodejs/assign_names_apply.go
+++ b/gen/nodejs/assign_names_apply.go
@@ -68,7 +68,7 @@ func (nt *applyNameTable) bestArgName(n *il.BoundVariableAccess) string {
 		return nt.tsName(fields[0])
 	case *config.ResourceVariable:
 		// If dealing with a data source or a broken access, use the resource's variable name.
-		if nt.g.resourceMode(n) != config.ManagedResourceMode || len(n.Elements) == 0 {
+		if nt.g.isDataSourceAccess(n) || len(n.Elements) == 0 {
 			return nt.g.variableName(n)
 		}
 
@@ -92,7 +92,7 @@ func (nt *applyNameTable) disambiguateArgName(n *il.BoundVariableAccess, bestNam
 	case *config.ResourceVariable:
 		// If dealing with a data source, hand off to the generic disambiguator. Otherwise, attempt to disambiguate
 		// by prepending the resource's variable name.
-		if nt.g.resourceMode(n) != config.ManagedResourceMode || len(n.Elements) == 0 {
+		if nt.g.isDataSourceAccess(n) || len(n.Elements) == 0 {
 			return nt.disambiguate(bestName)
 		}
 		return nt.disambiguate(nt.g.variableName(n) + title(bestName))

--- a/gen/nodejs/assign_names_test.go
+++ b/gen/nodejs/assign_names_test.go
@@ -29,7 +29,7 @@ import (
 func outputs(names []string) map[string]*il.OutputNode {
 	m := make(map[string]*il.OutputNode)
 	for _, name := range names {
-		m[name] = &il.OutputNode{Config: &config.Output{Name: name}}
+		m[name] = &il.OutputNode{Name: name}
 	}
 	return m
 }
@@ -37,7 +37,7 @@ func outputs(names []string) map[string]*il.OutputNode {
 func locals(names []string) map[string]*il.LocalNode {
 	m := make(map[string]*il.LocalNode)
 	for _, name := range names {
-		m[name] = &il.LocalNode{Config: &config.Local{Name: name}}
+		m[name] = &il.LocalNode{Name: name}
 	}
 	return m
 }
@@ -45,7 +45,7 @@ func locals(names []string) map[string]*il.LocalNode {
 func variables(names []string) map[string]*il.VariableNode {
 	m := make(map[string]*il.VariableNode)
 	for _, name := range names {
-		m[name] = &il.VariableNode{Config: &config.Variable{Name: name}}
+		m[name] = &il.VariableNode{Name: name}
 	}
 	return m
 }
@@ -53,7 +53,7 @@ func variables(names []string) map[string]*il.VariableNode {
 func modules(names []string) map[string]*il.ModuleNode {
 	m := make(map[string]*il.ModuleNode)
 	for _, name := range names {
-		m[name] = &il.ModuleNode{Config: &config.Module{Name: name}}
+		m[name] = &il.ModuleNode{Name: name}
 	}
 	return m
 }
@@ -65,9 +65,9 @@ func resources(toks []string) map[string]*il.ResourceNode {
 		components := strings.Split(tok, "::")
 		typ, name := tokens.Type(components[0]), components[1]
 
-		mode := config.ManagedResourceMode
+		isDataSource := false
 		if strings.HasPrefix(string(typ.Name()), "get") {
-			mode = config.DataResourceMode
+			isDataSource = true
 		}
 
 		tfType := string(typ.Package()) + "_" +
@@ -87,12 +87,10 @@ func resources(toks []string) map[string]*il.ResourceNode {
 		}
 
 		m[tok] = &il.ResourceNode{
-			Config: &config.Resource{
-				Name: name,
-				Type: tfType,
-				Mode: mode,
-			},
-			Provider: provider,
+			Name:         name,
+			Type:         tfType,
+			IsDataSource: isDataSource,
+			Provider:     provider,
 		}
 	}
 	return m

--- a/gen/nodejs/generator_test.go
+++ b/gen/nodejs/generator_test.go
@@ -75,7 +75,7 @@ func TestLowerToLiteral(t *testing.T) {
 
 	g := &generator{
 		rootPath: ".",
-		module:   &il.Graph{Tree: module.NewTree("foo", &config.Config{Dir: "./foo/bar"})},
+		module:   &il.Graph{IsRoot: true, Path: "./foo/bar"},
 	}
 	g.Emitter = gen.NewEmitter(nil, g)
 

--- a/gen/nodejs/hil.go
+++ b/gen/nodejs/hil.go
@@ -122,9 +122,9 @@ func (g *generator) genApply(w io.Writer, n *il.BoundCall) {
 // examine the type and name of each property accessed by the expression.
 func (g *generator) getNestedPropertyAccessElementInfo(v *il.BoundVariableAccess) (il.Schemas, []string) {
 	sch, elements := v.Schemas, v.Elements
-	if g.resourceMode(v) == config.ManagedResourceMode {
+	if !g.isDataSourceAccess(v) {
 		return sch.PropertySchemas(elements[0]), elements[1:]
-	} else if r, ok := v.ILNode.(*il.ResourceNode); ok && r.Provider.Config.Name == "http" {
+	} else if r, ok := v.ILNode.(*il.ResourceNode); ok && r.Provider.Name == "http" {
 		return sch, nil
 	}
 	return sch, elements
@@ -509,7 +509,7 @@ func (g *generator) GenVariableAccess(w io.Writer, n *il.BoundVariableAccess) {
 
 		// Otherwise, we will generate different code depending on whether or not we have a managed resource or a data
 		// source. The former are bags of outputs while the latter are outputs.
-		if g.resourceMode(n) == config.ManagedResourceMode {
+		if !g.isDataSourceAccess(n) {
 			// Because a managed resource is a bag of outputs, we must generate the first portion of this access. If we
 			// are _not_ within an apply, we generate the entire access.
 			element := n.Elements[0]

--- a/gen/nodejs/http.go
+++ b/gen/nodejs/http.go
@@ -29,7 +29,7 @@ import (
 func (g *generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count string) (string, error) {
 	urlProperty, ok := r.Properties.Elements["url"]
 	if !ok {
-		return "", errors.Errorf("missing required property \"url\" in resource %s", r.Config.Name)
+		return "", errors.Errorf("missing required property \"url\" in resource %s", r.Name)
 	}
 	url, _, err := g.computeProperty(urlProperty, indent, count)
 	if err != nil {
@@ -56,7 +56,7 @@ func (g *generator) computeHTTPInputs(r *il.ResourceNode, indent bool, count str
 
 // generateHTTP generates the given http resource as a call to request-promise-native's single exported function.
 func (g *generator) generateHTTP(r *il.ResourceNode) error {
-	contract.Require(r.Provider.Config.Name == "http", "r")
+	contract.Require(r.Provider.Name == "http", "r")
 
 	name := g.nodeName(r)
 

--- a/gen/nodejs/lower.go
+++ b/gen/nodejs/lower.go
@@ -38,7 +38,7 @@ func (g *generator) lowerToLiterals(prop il.BoundNode) (il.BoundNode, error) {
 
 		switch pv.Type {
 		case config.PathValueModule:
-			path := g.module.Tree.Config().Dir
+			path := g.module.Path
 
 			// Attempt to make this path relative to that of the root module.
 			rel, err := filepath.Rel(g.rootPath, path)

--- a/il/graph_config.go
+++ b/il/graph_config.go
@@ -1,0 +1,134 @@
+package il
+
+import "github.com/hashicorp/terraform/config"
+
+// nodeSet is a set of Node values.
+type nodeSet map[Node]struct{}
+
+// add adds a new Node to the set.
+func (s nodeSet) add(n Node) {
+	s[n] = struct{}{}
+}
+
+// moduleConfig represents the configuration for a single module.
+type moduleConfig interface {
+	providers() []string
+
+	bind(b *builder, name string) (*BoundMapProperty, nodeSet, error)
+}
+
+// providerConfig represents the configuration for a single provider.
+type providerConfig interface {
+	bind(b *builder, name string) (*BoundMapProperty, nodeSet, error)
+}
+
+// resourceConfig represents the configuration for a single resource.
+type resourceConfig interface {
+	providerName() string
+	ignoreChanges() []string
+	dependsOn() []string
+
+	bindCount(b *builder, name string) (BoundNode, nodeSet, error)
+	bindProperties(b *builder, name string, schemas Schemas, hasCount bool) (*BoundMapProperty, nodeSet, error)
+}
+
+// outputConfig represents the configuration for a single output.
+type outputConfig interface {
+	dependsOn() []string
+
+	bind(b *builder, name string) (*BoundMapProperty, nodeSet, error)
+}
+
+// localConfig represents the configuration for a single local.
+type localConfig interface {
+	bind(b *builder, name string) (*BoundMapProperty, nodeSet, error)
+}
+
+// variableConfig represents the configuration for a single variable.
+type variableConfig interface {
+	bind(b *builder, name string) (BoundNode, nodeSet, error)
+}
+
+// tf11ModuleConfig is an implementation of moduleConfig that is backed by a TF11 module config.
+type tf11ModuleConfig struct {
+	config *config.Module
+}
+
+func (c *tf11ModuleConfig) providers() []string {
+	providers := make([]string, 0, len(c.config.Providers))
+	for _, p := range c.config.Providers {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+func (c *tf11ModuleConfig) bind(b *builder, name string) (*BoundMapProperty, nodeSet, error) {
+	return b.bindProperties(name, c.config.RawConfig, Schemas{}, false)
+}
+
+// tf11ProviderConfig is an implementation of providerConfig that is backed by a TF11 resource config.
+type tf11ProviderConfig struct {
+	config *config.ProviderConfig
+}
+
+func (c *tf11ProviderConfig) bind(b *builder, name string) (*BoundMapProperty, nodeSet, error) {
+	return b.bindProperties(name, c.config.RawConfig, Schemas{}, false)
+}
+
+// tf11ResourceConfig is an implementation of resourceConfig that is backed by a TF11 resource config.
+type tf11ResourceConfig struct {
+	config *config.Resource
+}
+
+func (c *tf11ResourceConfig) providerName() string {
+	return c.config.ProviderFullName()
+}
+
+func (c *tf11ResourceConfig) ignoreChanges() []string {
+	return c.config.Lifecycle.IgnoreChanges
+}
+
+func (c *tf11ResourceConfig) dependsOn() []string {
+	return c.config.DependsOn
+}
+
+func (c *tf11ResourceConfig) bindCount(b *builder, name string) (BoundNode, nodeSet, error) {
+	return b.bindProperty(name, c.config.RawCount.Value(), Schemas{}, false)
+}
+
+func (c *tf11ResourceConfig) bindProperties(
+	b *builder, name string, schemas Schemas, hasCount bool) (*BoundMapProperty, nodeSet, error) {
+
+	return b.bindProperties(name, c.config.RawConfig, schemas, hasCount)
+}
+
+// tf11OutputConfig is an implementation of outputConfig that is backed by a TF11 output config.
+type tf11OutputConfig struct {
+	config *config.Output
+}
+
+func (c *tf11OutputConfig) dependsOn() []string {
+	return c.config.DependsOn
+}
+
+func (c *tf11OutputConfig) bind(b *builder, name string) (*BoundMapProperty, nodeSet, error) {
+	return b.bindProperties(name, c.config.RawConfig, Schemas{}, false)
+}
+
+// tf11LocalConfig is an implementation of localConfig that is backed by a TF11 local config.
+type tf11LocalConfig struct {
+	config *config.Local
+}
+
+func (c *tf11LocalConfig) bind(b *builder, name string) (*BoundMapProperty, nodeSet, error) {
+	return b.bindProperties(name, c.config.RawConfig, Schemas{}, false)
+}
+
+// tf11VariableConfig is an implementation of variableConfig that is backed by a TF11 variable config.
+type tf11VariableConfig struct {
+	config *config.Variable
+}
+
+func (c *tf11VariableConfig) bind(b *builder, name string) (BoundNode, nodeSet, error) {
+	return b.bindProperty(name, c.config.Default, Schemas{}, false)
+}

--- a/il/rewriters.go
+++ b/il/rewriters.go
@@ -197,7 +197,7 @@ func RewriteAssets(n BoundNode) (BoundNode, error) {
 			// pass the variable directly.
 			isArchiveResource := false
 			if v, ok := e.(*BoundVariableAccess); ok {
-				if r, ok := v.ILNode.(*ResourceNode); ok && r.Provider.Config.Name == "archive" {
+				if r, ok := v.ILNode.(*ResourceNode); ok && r.Provider.Name == "archive" {
 					v.Elements = nil
 					isArchiveResource = true
 				}
@@ -245,7 +245,7 @@ func MarkPromptDataSources(g *Graph) map[*ResourceNode]bool {
 
 		// First, check all data sources for output-typed inputs.
 		for _, r := range g.Resources {
-			if r.Config.Mode == config.DataResourceMode {
+			if r.IsDataSource {
 				containsOutputs := false
 				_, err := VisitBoundNode(r.Properties, IdentityVisitor, func(n BoundNode) (BoundNode, error) {
 					containsOutputs = containsOutputs || n.Type().IsOutput()

--- a/il/rewriters_test.go
+++ b/il/rewriters_test.go
@@ -50,7 +50,7 @@ func TestMarkPromptDataSources(t *testing.T) {
 
 		actual := make(map[string]bool)
 		for n := range set {
-			actual[n.Config.Id()] = true
+			actual[n.resourceID()] = true
 		}
 
 		assert.Equal(t, expected, actual)


### PR DESCRIPTION
- Remove the usage of module.Tree
- Stop exporting raw resource/local/variable/etc. config from IL nodes

With these changes, the core of the IL no longer depends on TF11. The
remaining use of TF11 types is `BoundVariableAccess.TFVar`. For the sake
of simplicity, this will likely switch to using the TF12 equivalent in
the future.