### PR TITLE
Reverse the default for `typescript.synchronous-data-sources`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 Pulumi.*.yaml
 
 **/command-output/
+
+.terraform
+package-lock.json
+terraform.tfstate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Change default to generate asynchronous data source calls instead of synchronous.
+  [#146](https://github.com/pulumi/tf2pulumi/pull/146)
 - Support importing resources from existing `.tfstate` files. [#142](https://github.com/pulumi/tf2pulumi/pull/142)
 
 ## v0.6.0 (Released September 30, 2019)

--- a/gen/nodejs/generator.go
+++ b/gen/nodejs/generator.go
@@ -683,9 +683,9 @@ func (g *generator) generateResource(r *il.ResourceNode) error {
 		resourceOptions = append(resourceOptions, buf.String())
 	}
 
-	optionsBag := ""
+	optionsBag := "{ async: true }"
 	if len(resourceOptions) != 0 {
-		optionsBag = fmt.Sprintf("{%s}", strings.Join(resourceOptions, ","))
+		optionsBag = fmt.Sprintf("{ async: true, %s}", strings.Join(resourceOptions, ","))
 	}
 
 	name := g.nodeName(r)

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"sets the language to target")
 	flag.StringVar(&opts.TargetSDKVersion, "target-sdk-version", "0.17.28",
 		"sets the language SDK version to target")
-	flag.BoolVar(&nodeJSOpts.UsePromptDataSources, "typescript.synchronous-data-sources", true,
+	flag.BoolVar(&nodeJSOpts.UsePromptDataSources, "typescript.synchronous-data-sources", false,
 		"enables or disables synchronous data sources in generated TypeScript code")
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",

--- a/tests/terraform/aws/ec2/index.base.ts
+++ b/tests/terraform/aws/ec2/index.base.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 // Originally defined at main.tf:5
-const ubuntu = aws.getAmi({
+const ubuntu = pulumi.output(aws.getAmi({
     filters: [
         {
             name: "name",
@@ -15,7 +15,7 @@ const ubuntu = aws.getAmi({
     ],
     mostRecent: true,
     owners: ["099720109477"],
-});
+}, { async: true }));
 // Originally defined at main.tf:21
 const web = new aws.ec2.Instance("web", {
     ami: ubuntu.id,


### PR DESCRIPTION
We no longer want to promote the use of synchronous data sources as they can lead to hangs.  tf2pulumi should default to *not* emitting synchronous invokes.

Fixes #144.