### PR TITLE
Log to the configured logger.

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -163,3 +163,10 @@ type Options struct {
 	// TargetOptions captures any target-specific options.
 	TargetOptions interface{}
 }
+
+// logf writes a formatted message to the configured logger, if any.
+func (o Options) logf(format string, arguments ...interface{}) {
+	if o.Logger != nil {
+		o.Logger.Printf(format, arguments...)
+	}
+}

--- a/convert/tf12.go
+++ b/convert/tf12.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"sort"
 	"strings"
 
@@ -150,9 +149,9 @@ func convertTF12(files []*syntax.File, opts Options) ([]*syntax.File, *hcl2.Prog
 		file.output.Reset()
 
 		if pulumiParser.Diagnostics.HasErrors() {
-			log.Printf("%v", contents)
-			log.Printf("%v", diagnostics)
-			log.Printf("%v", pulumiParser.Diagnostics)
+			opts.logf("%v", contents)
+			opts.logf("%v", diagnostics)
+			opts.logf("%v", pulumiParser.Diagnostics)
 			contract.Fail()
 		}
 	}


### PR DESCRIPTION
Or do not log at all, if no logger is present.