### PR TITLE
fix build arch in archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,9 @@ archives:
   format_overrides:
     - goos: windows
       format: zip
+  replacements:
+      amd64: x64
+      386: x86
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
 changelog:


### PR DESCRIPTION
A lot of our tools assume this format, so replacement amd64 -> arch