### PR TITLE
Concurrency-proof the info cache.

### DIFF
--- a/il/plugin_info.go
+++ b/il/plugin_info.go
@@ -53,8 +53,7 @@ func (cache *CachingProviderInfoSource) getProviderInfo(tfProviderName string) (
 // GetProviderInfo returns the tfbridge information for the indicated Terraform provider as well as the name of the
 // corresponding Pulumi resource provider.
 func (cache *CachingProviderInfoSource) GetProviderInfo(tfProviderName string) (*tfbridge.ProviderInfo, error) {
-	info, ok := cache.getProviderInfo(tfProviderName)
-	if ok {
+	if info, ok := cache.getProviderInfo(tfProviderName); ok {
 		return info, nil
 	}
 

--- a/il/plugin_info.go
+++ b/il/plugin_info.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"sync"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -35,21 +36,33 @@ type ProviderInfoSource interface {
 
 // CachingProviderInfoSource wraps a ProviderInfoSource in a cache for faster access.
 type CachingProviderInfoSource struct {
+	m sync.RWMutex
+
 	source  ProviderInfoSource
 	entries map[string]*tfbridge.ProviderInfo
+}
+
+func (cache *CachingProviderInfoSource) getProviderInfo(tfProviderName string) (*tfbridge.ProviderInfo, bool) {
+	cache.m.RLock()
+	defer cache.m.RUnlock()
+
+	info, ok := cache.entries[tfProviderName]
+	return info, ok
 }
 
 // GetProviderInfo returns the tfbridge information for the indicated Terraform provider as well as the name of the
 // corresponding Pulumi resource provider.
 func (cache *CachingProviderInfoSource) GetProviderInfo(tfProviderName string) (*tfbridge.ProviderInfo, error) {
-	info, ok := cache.entries[tfProviderName]
-	if !ok {
-		i, err := cache.source.GetProviderInfo(tfProviderName)
-		if err != nil {
-			return nil, err
-		}
-		cache.entries[tfProviderName], info = i, i
+	info, ok := cache.getProviderInfo(tfProviderName)
+	if ok {
+		return info, nil
 	}
+
+	info, err := cache.source.GetProviderInfo(tfProviderName)
+	if err != nil {
+		return nil, err
+	}
+	cache.entries[tfProviderName] = info
 	return info, nil
 }
 


### PR DESCRIPTION
Use an RWMutex to protect cache accesses and insertions. This allows the
cache to be safely used from multiple goroutines concurrently.