### PR TITLE
[tf12] Respect the provider info source option.

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -63,6 +63,9 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 		}
 		opts.Root = afero.NewBasePathFs(afero.NewOsFs(), cwd)
 	}
+	if opts.ProviderInfoSource == nil {
+		opts.ProviderInfoSource = il.PluginProviderInfoSource
+	}
 
 	// Attempt to load the config as TF11 first. If this succeeds, use TF11 semantics unless either the config
 	// or the options specify otherwise.

--- a/convert/tf12.go
+++ b/convert/tf12.go
@@ -92,7 +92,7 @@ func convertTF12(files []*syntax.File, opts Options) ([]*syntax.File, *hcl2.Prog
 		hcl2Options:         hcl2Options,
 		pulumiOptions:       pulumiOptions,
 		filterResourceNames: opts.FilterResourceNames,
-		providerInfo:        il.PluginProviderInfoSource,
+		providerInfo:        opts.ProviderInfoSource,
 		providers:           map[string]*tfbridge.ProviderInfo{},
 		binding:             codegen.Set{},
 		bound:               codegen.Set{},


### PR DESCRIPTION
Rather than using the default plugin-based info source, respect the info
source present in the options.

This speeds up tfgen for providers with large numbers of examples by
about 10x, since it makes proper use of the caching info source.