### PR TITLE
[tf11] Fix template escaping.

### DIFF
--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -1,0 +1,172 @@
+name: Downstream Codegen Tests
+on:
+  pull_request:
+    paths:
+    - 'pkg/codegen/**'
+    - '.github/workflows/codegen-test.yml'
+
+jobs:
+  downstream-aws:
+    name: Test AWS Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/tf2pulumi=tf2pulumi
+          downstream-name: pulumi-aws
+          downstream-url: https://github.com/pulumi/pulumi-aws
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-azure:
+    name: Test Azure Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/tf2pulumi=tf2pulumi
+          downstream-name: pulumi-azure
+          downstream-url: https://github.com/pulumi/pulumi-azure
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-gcp:
+    name: Test GCP Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/tf2pulumi=tf2pulumi
+          downstream-name: pulumi-gcp
+          downstream-url: https://github.com/pulumi/pulumi-gcp
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-azuread:
+    name: Test AzureAD Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/tf2pulumi=tf2pulumi
+          downstream-name: pulumi-azuread
+          downstream-url: https://github.com/pulumi/pulumi-azuread
+          use-provider-dir: true
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+
+  downstream-random:
+    name: Test Random Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/tf2pulumi=tf2pulumi
+          downstream-name: pulumi-random
+          downstream-url: https://github.com/pulumi/pulumi-random
+          use-provider-dir: true
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}

--- a/convert/tf11.go
+++ b/convert/tf11.go
@@ -547,14 +547,16 @@ func (g *tf11generator) GenIndex(w io.Writer, n *il.BoundIndex) {
 }
 
 func (g *tf11generator) genEscapedString(b *strings.Builder, v string, heredoc bool) {
-	for _, c := range v {
+	for i, c := range v {
 		switch c {
 		case '"', '\\':
 			if !heredoc {
 				b.WriteRune('\\')
 			}
-		case '$':
-			b.WriteRune('$')
+		case '$', '%':
+			if i+1 < len(v) && v[i+1] == '{' {
+				b.WriteRune(c)
+			}
 		}
 		b.WriteRune(c)
 	}


### PR DESCRIPTION
'$' and '%' only need to be escaped if they immediately precede a '{'.

These changes also add downstream codegen testing.

Fixes https://github.com/pulumi/pulumi/issues/4776.