### PR TITLE
[tf12] Translate nested block names.

### DIFF
--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -1,9 +1,5 @@
 name: Downstream Codegen Tests
-on:
-  pull_request:
-    paths:
-    - 'pkg/codegen/**'
-    - '.github/workflows/codegen-test.yml'
+on: [pull_request]
 
 jobs:
   downstream-aws:

--- a/convert/tf11.go
+++ b/convert/tf11.go
@@ -23,6 +23,10 @@ import (
 )
 
 // convertTF11 converts a TF11 graph to a set of TF12 files.
+//
+// Note that the output of the conversion process may not be valid input for Terraform itself: in particular, the block
+// structure of the original source code may not be preserved, so entities that were blocks in the input may be
+// attributes in the output. The TF12 -> PCL converter must be able to handle this sort of input.
 func convertTF11(opts Options) (map[string][]byte, bool, error) {
 	moduleStorage := tf11module.NewStorage(filepath.Join(".terraform", "modules"))
 

--- a/convert/tf12.go
+++ b/convert/tf12.go
@@ -1121,8 +1121,9 @@ func (rr *resourceRewriter) rewriteObjectKeys(expr model.Expression) {
 			keyVal := ""
 			if !useExactKeys {
 				if key, ok := item.Key.(*model.LiteralValueExpression); ok && key.Value.Type().Equals(cty.String) {
-					keyVal = rr.terraformToPulumiName(key.Value.AsString())
-					key.Value = cty.StringVal(keyVal)
+					keyVal := key.Value.AsString()
+					propSch := rr.schemas().PropertySchemas(keyVal)
+					key.Value = cty.StringVal(terraformToPulumiName(keyVal, propSch))
 				}
 			}
 

--- a/convert/tf12.go
+++ b/convert/tf12.go
@@ -1291,7 +1291,8 @@ func (rr *resourceRewriter) rewriteBodyItem(item model.BodyItem) (model.BodyItem
 			_, isList := propSch.ModelType().(*model.ListType)
 			projectListElement := isList && tfbridge.IsMaxItemsOne(propSch.TF, propSch.Pulumi)
 
-			tokens := syntax.NewAttributeTokens(block.Type)
+			name := rr.terraformToPulumiName(block.Type)
+			tokens := syntax.NewAttributeTokens(name)
 
 			var value model.Expression
 			if !projectListElement || len(objects) > 1 {
@@ -1327,7 +1328,7 @@ func (rr *resourceRewriter) rewriteBodyItem(item model.BodyItem) (model.BodyItem
 
 			items = append(items, &model.Attribute{
 				Tokens: tokens,
-				Name:   block.Type,
+				Name:   name,
 				Value:  value,
 			})
 		}

--- a/convert/tf12.go
+++ b/convert/tf12.go
@@ -1069,12 +1069,15 @@ func (rr *resourceRewriter) appendOption(item *model.Attribute) model.BodyItem {
 	return result
 }
 
-func (rr *resourceRewriter) terraformToPulumiName(tfName string) string {
-	schemas := rr.schemas()
+func terraformToPulumiName(tfName string, schemas il.Schemas) string {
 	if schemas.Pulumi != nil && schemas.Pulumi.Name != "" {
 		return schemas.Pulumi.Name
 	}
 	return tfbridge.TerraformToPulumiName(tfName, schemas.TF, schemas.Pulumi, false)
+}
+
+func (rr *resourceRewriter) terraformToPulumiName(tfName string) string {
+	return terraformToPulumiName(tfName, rr.schemas())
 }
 
 func (rr *resourceRewriter) enterBodyItem(item model.BodyItem) (model.BodyItem, hcl.Diagnostics) {
@@ -1291,7 +1294,7 @@ func (rr *resourceRewriter) rewriteBodyItem(item model.BodyItem) (model.BodyItem
 			_, isList := propSch.ModelType().(*model.ListType)
 			projectListElement := isList && tfbridge.IsMaxItemsOne(propSch.TF, propSch.Pulumi)
 
-			name := rr.terraformToPulumiName(block.Type)
+			name := terraformToPulumiName(block.Type, propSch)
 			tokens := syntax.NewAttributeTokens(name)
 
 			var value model.Expression


### PR DESCRIPTION
Use the `terraformToPulumiName` method to translate the names of nested
blocks from Terraform to Pulumi names.

Fixes #193.