### PR TITLE
Show diagnostics from TF12 if using version 12

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -97,6 +97,8 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 		files, diags := parseTF12(opts)
 		if !diags.HasErrors() {
 			tf12Files, diagnostics = files, append(diagnostics, diags...)
+		} else if opts.TerraformVersion != "11" {
+			return nil, Diagnostics{All: diags, files: files}, nil
 		} else {
 			return nil, Diagnostics{}, tf11Err
 		}


### PR DESCRIPTION
If the --terraform-version 12 option is used, then print the
diagnostic messages from the terraform 0.12 parsing rather than the 0.11
parsing.