### PR TITLE
tests: fix flakiness by reducing parallelism

### DIFF
--- a/tests/terraform/aws/aws_test.go
+++ b/tests/terraform/aws/aws_test.go
@@ -43,7 +43,7 @@ func RunAWSTest(t *testing.T, dir string, opts ...terraform.TestOptionsFunc) {
 }
 
 func TestASG(t *testing.T) {
-	RunAWSTest(t, "asg")
+	RunAWSTest(t, "asg", terraform.NoParallel())
 }
 
 func TestCognitoUserPool(t *testing.T) {
@@ -60,16 +60,16 @@ func TestECSALB(t *testing.T) {
 }
 
 func TestEIP(t *testing.T) {
-	RunAWSTest(t, "eip")
+	RunAWSTest(t, "eip", terraform.NoParallel())
 }
 
 func TestELB(t *testing.T) {
 	// Skip Python due to a bug in depends_on codegen
-	RunAWSTest(t, "elb", terraform.SkipPython())
+	RunAWSTest(t, "elb", terraform.SkipPython(), terraform.NoParallel())
 }
 
 func TestELB2(t *testing.T) {
-	RunAWSTest(t, "elb2")
+	RunAWSTest(t, "elb2", terraform.NoParallel())
 }
 
 func TestLBListener(t *testing.T) {

--- a/tests/terraform/aws/ec2/__main__.base.py
+++ b/tests/terraform/aws/ec2/__main__.base.py
@@ -1,12 +1,12 @@
 import pulumi
 import pulumi_aws as aws
 
-ubuntu = aws.get_ami(filters=[
-        aws.GetAmiFilterArgs(
+ubuntu = aws.ec2.get_ami(filters=[
+        aws.ec2.GetAmiFilterArgs(
             name="name",
             values=["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"],
         ),
-        aws.GetAmiFilterArgs(
+        aws.ec2.GetAmiFilterArgs(
             name="virtualization-type",
             values=["hvm"],
         ),

--- a/tests/terraform/aws/ec2/index.base.ts
+++ b/tests/terraform/aws/ec2/index.base.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 // Originally defined at main.tf:5
-const ubuntu = pulumi.output(aws.getAmi({
+const ubuntu = pulumi.output(aws.ec2.getAmi({
     filters: [
         {
             name: "name",

--- a/tests/terraform/aws/ec2/main.tf
+++ b/tests/terraform/aws/ec2/main.tf
@@ -3,10 +3,10 @@ provider "aws" {
 }
 
 data "aws_ami" "ubuntu" {
-  most_recent = true,
+  most_recent = true
 
   filter {
-    name = "name",
+    name = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
   }
 

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -69,7 +69,11 @@ func (c ConvertOptions) With(other ConvertOptions) ConvertOptions {
 // Run executes this test, spawning subtests for each supported target.
 func (test Test) Run(t *testing.T) {
 	t.Helper()
-	t.Parallel()
+	// Double negative cannot be helped, this is intended to mitigate test failures where a global
+	// resource is manipulated, e.g.: the default AWS security group.
+	if !test.RunOptions.NoParallel {
+		t.Parallel()
+	}
 	t.Run("Python", func(t *testing.T) {
 		runOpts := integration.ProgramTestOptions{}
 		if test.RunOptions != nil {
@@ -281,6 +285,11 @@ func FilterName(value string) TestOptionsFunc {
 // Skip skips the test for the given reason.
 func Skip(reason string) TestOptionsFunc {
 	return func(_ *testing.T, test *Test) { test.Options.Skip = reason }
+}
+
+// Sets the NoParallel flag on the test to run
+func NoParallel() TestOptionsFunc {
+	return func(_ *testing.T, test *Test) { test.RunOptions.NoParallel = true }
 }
 
 // AllowChanges allows changes on the empty preview and update for the given test.

--- a/tests/terraform/tests.go
+++ b/tests/terraform/tests.go
@@ -68,6 +68,7 @@ func (c ConvertOptions) With(other ConvertOptions) ConvertOptions {
 
 // Run executes this test, spawning subtests for each supported target.
 func (test Test) Run(t *testing.T) {
+	t.Logf("Starting test %v", t.Name())
 	t.Helper()
 	// Double negative cannot be helped, this is intended to mitigate test failures where a global
 	// resource is manipulated, e.g.: the default AWS security group.


### PR DESCRIPTION
Add a NoParallel test option and apply it to four AWS tests.

Fixes #247 


