### PR TITLE
TF 0.12 module support

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ Pulumi TypeScript program that describes the same resource graph.`,
 		"allows code generation to continue if there are errors extracting comments")
 	flag.BoolVar(&opts.AnnotateNodesWithLocations, "record-locations", false,
 		"annotate the generated code with original source locations for each resource")
+	flag.BoolVar(&opts.ConvertToComponentResource, "convert-to-component-resource", false,
+		"converts the project to a Pulumi Component Resource if true, and to a standard program if false")
 	flag.BoolVar(&tarout, "tar", false,
 		"generate a TAR archive to stdout instead of writing to the filesystem")
 	flag.StringVar(&resourceNameProperty, "filter-resource-names", "",


### PR DESCRIPTION
Fully implementing Terraform 0.12 Module conversion for all languages so that support for Terraform 0.13 and beyond can be added (#186).