### PR TITLE
Change badge from Travis to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf2pulumi
 
-[![Build Status](https://travis-ci.com/pulumi/tf2pulumi.svg?branch=master)](https://travis-ci.com/pulumi/tf2pulumi)
+[![Build Status](https://github.com/pulumi/tf2pulumi/actions/workflows/master.yml/badge.svg)](https://github.com/pulumi/tf2pulumi/actions/workflows/master.yml)
 
 Convert Terraform projects to Pulumi TypeScript programs.
 


### PR DESCRIPTION
Change the status badge in the README to use GitHub Actions instead of Travis.

It looks like we moved off Travis awhile ago. The badge was failing, and clicking on the badge results in a 404. This PR replaces the Travis status badge with a GitHub Actions badge instead.