### PR TITLE
Update release.yml to use macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes publish by using a MacOS goreleaser agent, because there's a dependency (notify) that uses CGO on darwin that can't be cross-compiled from Linux.